### PR TITLE
Blank space before comma in d2 function arguments

### DIFF
--- a/src/main/java/org/hisp/dhis/rules/RuleFunctionCall.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleFunctionCall.java
@@ -55,7 +55,11 @@ abstract class RuleFunctionCall
                 List<String> params = new ArrayList<>();
                 while ( splitParametersMatcher.find() )
                 {
-                        params.add( splitParametersMatcher.group().trim() );
+                        String param = splitParametersMatcher.group().trim();
+                        if ( !"".equals( param ) )
+                        {
+                                params.add( param );
+                        }
                 }
 
                 return new AutoValue_RuleFunctionCall( functionCall, String.format( Locale.US,

--- a/src/test/java/org/hisp/dhis/rules/RuleFunctionCallTests.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleFunctionCallTests.java
@@ -1,6 +1,5 @@
 package org.hisp.dhis.rules;
 
-import org.hisp.dhis.rules.RuleFunctionCall;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -45,6 +44,17 @@ public class RuleFunctionCallTests
                 assertThat( ruleFunctionCall.functionCall() ).isEqualTo( "d2:some()" );
                 assertThat( ruleFunctionCall.functionName() ).isEqualTo( "d2:some" );
                 assertThat( ruleFunctionCall.arguments().size() ).isEqualTo( 0 );
+        }
+
+        @Test
+        public void fromMustReturnFunctionCallWithBlankSpaceBetweenArguments()
+        {
+                RuleFunctionCall ruleFunctionCall = RuleFunctionCall.from( "d2:some('one' , 'two')" );
+                assertThat( ruleFunctionCall.functionCall() ).isEqualTo( "d2:some('one' , 'two')" );
+                assertThat( ruleFunctionCall.functionName() ).isEqualTo( "d2:some" );
+                assertThat( ruleFunctionCall.arguments().size() ).isEqualTo( 2 );
+                assertThat( ruleFunctionCall.arguments().get( 0 ) ).isEqualTo( "'one'" );
+                assertThat( ruleFunctionCall.arguments().get( 1 ) ).isEqualTo( "'two'" );
         }
 
         @Test


### PR DESCRIPTION
Related to this bug https://jira.dhis2.org/browse/ANDROSDK-298

The solution proposed is to ignore empty strings. An alternate solution would be to improve the regexp pattern to include trailing blank spaces (the ones between the end of parameter and the comma).

There is test covering this error