### PR TITLE
spaces-variable-name: support spaces in variable name

### DIFF
--- a/src/main/java/org/hisp/dhis/rules/RuleExpression.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleExpression.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 @AutoValue
 abstract class RuleExpression
 {
-        static final String VARIABLE_PATTERN = "[A#CV]\\{(\\w+.?\\w*)\\}";
+        static final String VARIABLE_PATTERN = "[A#CV]\\{([\\w\\s]+.?[\\w\\s]*)\\}";
 
         static final String FUNCTION_PATTERN = "d2:(\\w+.?\\w*)\\( *(([\\d/\\*\\+\\-%\\. ]+)|" +
             "( *'[^']*'))*( *, *(([\\d/\\*\\+\\-%\\. ]+)|'[^']*'))* *\\)";

--- a/src/test/java/org/hisp/dhis/rules/RuleExpressionTests.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleExpressionTests.java
@@ -24,6 +24,18 @@ public class RuleExpressionTests
         }
 
         @Test
+        public void fromShouldReturnExpressionWhenVariableNameHasSpaces()
+        {
+                String expression = "#{test_variable one} <0 && #{test variable two} == ''";
+
+                RuleExpression ruleExpression = RuleExpression.from( expression );
+                assertThat( ruleExpression.variables().size() ).isEqualTo( 2 );
+                assertThat( ruleExpression.variables() ).contains( "#{test_variable one}" );
+                assertThat( ruleExpression.variables() ).contains( "#{test variable two}" );
+                assertThat( ruleExpression.functions().size() ).isEqualTo( 0 );
+        }
+
+        @Test
         public void fromShouldReturnExpressionWithAttributeVariables()
         {
                 String expression = "A{test_variable_one} <0 && A{test_variable_two} == ''";


### PR DESCRIPTION
Related to [ANDROSDK-318](https://jira.dhis2.org/browse/ANDROSDK-318)

When the variable name has more than one space, the regexp in RuleExpression fails to identify the variable. 