### PR TITLE
Android refactor

### DIFF
--- a/src/main/java/org/hisp/dhis/rules/RuleEngineExecution.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleEngineExecution.java
@@ -51,7 +51,18 @@ class RuleEngineExecution
 
                 List<Rule> ruleList = new ArrayList<>( rules );
 
-                ruleList.sort( Comparator.comparing( Rule::priority, Comparator.nullsLast( Comparator.naturalOrder() ) ) );
+                Collections.sort(ruleList, (rule1, rule2) -> {
+                    Integer priority1 = rule1.priority();
+                    Integer priority2 = rule2.priority();
+                        if(priority1!=null && priority2 !=null)
+                                return priority1.compareTo(priority2);
+                        else if(priority1 != null)
+                                return -1;
+                        else if(priority2 != null)
+                                return 1;
+                        else
+                                return 0;
+                });
 
                 for ( int i = 0; i < ruleList.size(); i++ )
                 {

--- a/src/main/java/org/hisp/dhis/rules/RuleVariableValueMapBuilder.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleVariableValueMapBuilder.java
@@ -507,8 +507,13 @@ final class RuleVariableValueMapBuilder
 
         private String getLastUpdateDate( List<RuleDataValue> ruleDataValues )
         {
-            List<Date> dates = ruleDataValues.stream().map( RuleDataValue::eventDate ).filter( d -> !d.after( new Date() ) ).collect( Collectors.toList() );
-
+                List<Date> dates = new ArrayList<>();
+                for (RuleDataValue date : ruleDataValues) {
+                    Date d = date.eventDate();
+                    if (!d.after(new Date())) {
+                        dates.add(d);
+                    }
+                }
             return dateFormat.format( Collections.max( dates ) );
         }
 

--- a/src/main/java/org/hisp/dhis/rules/models/RuleValueType.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleValueType.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 
 public enum RuleValueType
 {
-        TEXT( "''" ), NUMERIC( "0.0" ), BOOLEAN( "" );
+        TEXT( "''" ), NUMERIC( "0.0" ), BOOLEAN( "false" );
 
         @Nonnull
         private final String defaultValue;

--- a/src/main/java/org/hisp/dhis/rules/models/RuleValueType.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleValueType.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 
 public enum RuleValueType
 {
-        TEXT( "''" ), NUMERIC( "0.0" ), BOOLEAN( "false" );
+        TEXT( "''" ), NUMERIC( "0.0" ), BOOLEAN( "" );
 
         @Nonnull
         private final String defaultValue;


### PR DESCRIPTION
Method sort for Lists and Comparators are not supported in android for api version lower than 24. Changes have been made to be able to give support from api 19.