### PR TITLE
feat: Support 1 and 0 in CountIfValue for boolean variables

### DIFF
--- a/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValue.java
+++ b/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValue.java
@@ -86,16 +86,22 @@ public class RuleFunctionCountIfValue extends RuleFunction
 
         RuleVariableValue variableValue = valueMap.get( ruleVariableName );
 
-        String valueToFind = arguments.get(1);
+        String valueToFind = arguments.get( 1 );
 
         if ( variableValue != null )
         {
-            if(variableValue.type() == RuleValueType.BOOLEAN){
-                if(valueToFind.equals("1"))
+            if ( variableValue.type() == RuleValueType.BOOLEAN )
+            {
+                if( valueToFind.equals( "1" ) )
+                {
                     valueToFind = "true";
-                else if(valueToFind.equals("0"))
+                }
+                else if ( valueToFind.equals( "0" ) )
+                {
                     valueToFind = "false";
+                }
             }
+
             return Integer.toString( Collections.frequency( variableValue.candidates(), valueToFind ) );
         }
         else

--- a/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValue.java
+++ b/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValue.java
@@ -28,29 +28,33 @@ package org.hisp.dhis.rules.functions;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.hisp.dhis.rules.RuleVariableValue;
-import org.hisp.dhis.rules.models.RuleValueType;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import org.hisp.dhis.rules.RuleVariableValue;
+import org.hisp.dhis.rules.models.RuleValueType;
+
 /**
  * @Author Zubair Asghar.
- * <p>
- * Counts the number of matching values that is entered for the source field in the first argument. Only occurrences that matches the second argument is counted.
- * The source field parameter is the name of one of the defined source fields in the program.
+ *         <p>
+ *         Counts the number of matching values that is entered for the source
+ *         field in the first argument. Only occurrences that matches the second
+ *         argument is counted. The source field parameter is the name of one of
+ *         the defined source fields in the program.
  */
-public class RuleFunctionCountIfValue extends RuleFunction
+public class RuleFunctionCountIfValue
+    extends
+    RuleFunction
 {
     static final String D2_COUNT_IF_VALUE = "d2:countIfValue";
 
     @Nonnull
     @Override
     public String evaluate( @Nonnull List<String> arguments, Map<String, RuleVariableValue> valueMap,
-                            Map<String, List<String>> supplementaryData )
+        Map<String, List<String>> supplementaryData )
     {
         if ( valueMap == null )
         {
@@ -59,8 +63,7 @@ public class RuleFunctionCountIfValue extends RuleFunction
 
         if ( arguments.size() != 2 )
         {
-            throw new IllegalArgumentException( "Two arguments were expected, " +
-                    arguments.size() + " were supplied" );
+            throw new IllegalArgumentException( "Two arguments were expected, " + arguments.size() + " were supplied" );
         }
 
         return countIfValue( arguments, valueMap );
@@ -73,11 +76,13 @@ public class RuleFunctionCountIfValue extends RuleFunction
     }
 
     /**
-     * Function which will return the count of argument[0].
-     * Program rule variable at argument[0] will only be counted if it satisfy to condition which is at argument[1]
+     * Function which will return the count of argument[0]. Program rule variable at
+     * argument[0] will only be counted if it satisfy to condition which is at
+     * argument[1]
      *
-     * @param arguments arguments for this function. First is the name of program rule variable and second is the condition
-     * @param valueMap  key value pair containing values for each variable
+     * @param arguments arguments for this function. First is the name of program
+     *        rule variable and second is the condition
+     * @param valueMap key value pair containing values for each variable
      * @return count of program rule variable
      */
     private String countIfValue( List<String> arguments, Map<String, RuleVariableValue> valueMap )
@@ -92,7 +97,7 @@ public class RuleFunctionCountIfValue extends RuleFunction
         {
             if ( variableValue.type() == RuleValueType.BOOLEAN )
             {
-                if( valueToFind.equals( "1" ) )
+                if ( valueToFind.equals( "1" ) )
                 {
                     valueToFind = "true";
                 }

--- a/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValue.java
+++ b/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValue.java
@@ -29,11 +29,13 @@ package org.hisp.dhis.rules.functions;
  */
 
 import org.hisp.dhis.rules.RuleVariableValue;
+import org.hisp.dhis.rules.models.RuleValueType;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import javax.annotation.Nonnull;
 
 /**
  * @Author Zubair Asghar.
@@ -84,9 +86,17 @@ public class RuleFunctionCountIfValue extends RuleFunction
 
         RuleVariableValue variableValue = valueMap.get( ruleVariableName );
 
+        String valueToFind = arguments.get(1);
+
         if ( variableValue != null )
         {
-            return Integer.toString( Collections.frequency( variableValue.candidates(), arguments.get( 1 ) ) );
+            if(variableValue.type() == RuleValueType.BOOLEAN){
+                if(valueToFind.equals("1"))
+                    valueToFind = "true";
+                else if(valueToFind.equals("0"))
+                    valueToFind = "false";
+            }
+            return Integer.toString( Collections.frequency( variableValue.candidates(), valueToFind ) );
         }
         else
         {

--- a/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionZScore.java
+++ b/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionZScore.java
@@ -29,10 +29,11 @@ package org.hisp.dhis.rules.functions;
  */
 
 import com.google.common.collect.Sets;
+
 import org.hisp.dhis.rules.RuleVariableValue;
 
-import javax.annotation.Nonnull;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,41 +41,36 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 /**
  * @Author Zubair Asghar.
  */
-public abstract class RuleFunctionZScore extends RuleFunction
-{
-    private static final Set<String> GENDER_CODES = Sets.newHashSet( "male", "MALE", "Male","ma", "m", "M", "0", "false" );
-    protected static final DecimalFormat format = new DecimalFormat( "###.00" );
+public abstract class RuleFunctionZScore extends RuleFunction {
+    private static final Set<String> GENDER_CODES = Sets.newHashSet("male", "MALE", "Male", "ma", "m", "M", "0", "false");
 
     @Nonnull
     @Override
-    public String evaluate( @Nonnull List<String> arguments, Map<String, RuleVariableValue> valueMap, Map<String, List<String>> supplementaryData )
-    {
-        if ( arguments.size() < 3 )
-        {
-            throw new IllegalArgumentException( "At least three arguments required but found: " + arguments.size() );
+    public String evaluate(@Nonnull List<String> arguments, Map<String, RuleVariableValue> valueMap, Map<String, List<String>> supplementaryData) {
+        if (arguments.size() < 3) {
+            throw new IllegalArgumentException("At least three arguments required but found: " + arguments.size());
         }
 
         // 1 = female, 0 = male
         float parameter;
         float weight;
-        byte gender = GENDER_CODES.contains( arguments.get( 2 ) ) ? (byte) 0 : (byte) 1;
+        byte gender = GENDER_CODES.contains(arguments.get(2)) ? (byte) 0 : (byte) 1;
 
         String zScore;
 
-        try
-        {
-            parameter = Float.parseFloat( arguments.get( 0 ) );
-            weight = Float.parseFloat( arguments.get( 1 ) );
-        }
-        catch ( NumberFormatException ex )
-        {
-            throw new IllegalArgumentException( "Byte parsing failed" );
+        try {
+            parameter = Float.parseFloat(arguments.get(0));
+            weight = Float.parseFloat(arguments.get(1));
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Byte parsing failed");
         }
 
-        zScore = getZScore( parameter, weight, gender );
+        zScore = getZScore(parameter, weight, gender);
 
         return zScore;
     }
@@ -83,50 +79,40 @@ public abstract class RuleFunctionZScore extends RuleFunction
 
     public abstract Map<ZScoreTableKey, Map<Float, Integer>> getTableForBoy();
 
-    private String getZScore( float parameter, float weight, byte gender )
-    {
-        ZScoreTableKey key = new ZScoreTableKey( gender, parameter );
+    private String getZScore(float parameter, float weight, byte gender) {
+        ZScoreTableKey key = new ZScoreTableKey(gender, parameter);
 
         Map<Float, Integer> sdMap = new HashMap<>();
 
         // Female
-        if ( gender == 1 )
-        {
-            sdMap = getTableForGirl().get( key );
-        }
-        else
-        {
+        if (gender == 1) {
+            sdMap = getTableForGirl().get(key);
+        } else {
             Map<ZScoreTableKey, Map<Float, Integer>> test = getTableForBoy();
-            sdMap = getTableForBoy().get( key );
+            sdMap = getTableForBoy().get(key);
         }
 
-        int multiplicationFactor = getMultiplicationFactor( sdMap, weight );
+        int multiplicationFactor = getMultiplicationFactor(sdMap, weight);
 
         // weight exactly matches with any of the SD values
-        if ( sdMap.keySet().contains( weight ) )
-        {
-            int sd = sdMap.get( weight );
+        if (sdMap.keySet().contains(weight)) {
+            int sd = sdMap.get(weight);
 
-            return String.valueOf( sd * multiplicationFactor );
+            return String.valueOf(sd * multiplicationFactor);
         }
 
         // weight is beyond -3SD or 3SD
-        if ( weight > Collections.max( sdMap.keySet() ) )
-        {
-            return String.valueOf( 3.5 );
-        }
-        else if ( weight < Collections.min( sdMap.keySet() ) )
-        {
-            return String.valueOf( -3.5 );
+        if (weight > Collections.max(sdMap.keySet())) {
+            return String.valueOf(3.5);
+        } else if (weight < Collections.min(sdMap.keySet())) {
+            return String.valueOf(-3.5);
         }
 
         float lowerLimitX = 0, higherLimitY = 0;
 
         // find the interval
-        for ( float f : sortKeySet( sdMap ) )
-        {
-            if (  weight > f )
-            {
+        for (float f : sortKeySet(sdMap)) {
+            if (weight > f) {
                 lowerLimitX = f;
                 continue;
             }
@@ -143,46 +129,46 @@ public abstract class RuleFunctionZScore extends RuleFunction
 
         float result;
 
-        if ( weight > findMedian( sdMap ) )
-        {
+        if (weight > findMedian(sdMap)) {
             gap = weight - lowerLimitX;
             decimalAddition = gap / distance;
-            result = sdMap.get( lowerLimitX ) + decimalAddition;
-        }
-        else
-        {
+            result = sdMap.get(lowerLimitX) + decimalAddition;
+        } else {
             gap = higherLimitY - weight;
             decimalAddition = gap / distance;
-            result = sdMap.get( higherLimitY ) + decimalAddition;
+            result = sdMap.get(higherLimitY) + decimalAddition;
         }
 
         result = result * multiplicationFactor;
 
-        return String.valueOf( format.format( result ) );
+        return String.valueOf(getDecimalFormat().format(result));
     }
 
-    private int getMultiplicationFactor( Map<Float, Integer> sdMap, float weight )
-    {
-        float median = findMedian( sdMap );
+    private int getMultiplicationFactor(Map<Float, Integer> sdMap, float weight) {
+        float median = findMedian(sdMap);
 
-        return Float.compare( weight, median );
+        return Float.compare(weight, median);
     }
 
-    private float findMedian( Map<Float, Integer> sdMap )
-    {
-        List<Float> sortedList = sortKeySet( sdMap );
+    private float findMedian(Map<Float, Integer> sdMap) {
+        List<Float> sortedList = sortKeySet(sdMap);
 
-        return sortedList.get( 3 );
+        return sortedList.get(3);
     }
 
-    private List<Float> sortKeySet( Map<Float, Integer> sdMap )
-    {
+    private List<Float> sortKeySet(Map<Float, Integer> sdMap) {
         Set<Float> keySet = sdMap.keySet();
 
-        List<Float> list = new ArrayList<>( keySet );
+        List<Float> list = new ArrayList<>(keySet);
 
-        Collections.sort( list );
+        Collections.sort(list);
 
         return list;
+    }
+
+    protected static DecimalFormat getDecimalFormat() {
+        DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance();
+        decimalFormatSymbols.setDecimalSeparator('.');
+        return new DecimalFormat("###.00", decimalFormatSymbols);
     }
 }

--- a/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionZScore.java
+++ b/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionZScore.java
@@ -46,31 +46,41 @@ import javax.annotation.Nonnull;
 /**
  * @Author Zubair Asghar.
  */
-public abstract class RuleFunctionZScore extends RuleFunction {
-    private static final Set<String> GENDER_CODES = Sets.newHashSet("male", "MALE", "Male", "ma", "m", "M", "0", "false");
+public abstract class RuleFunctionZScore
+    extends
+    RuleFunction
+{
+    private static final Set<String> GENDER_CODES = Sets.newHashSet( "male", "MALE", "Male", "ma", "m", "M", "0",
+        "false" );
 
     @Nonnull
     @Override
-    public String evaluate(@Nonnull List<String> arguments, Map<String, RuleVariableValue> valueMap, Map<String, List<String>> supplementaryData) {
-        if (arguments.size() < 3) {
-            throw new IllegalArgumentException("At least three arguments required but found: " + arguments.size());
+    public String evaluate( @Nonnull List<String> arguments, Map<String, RuleVariableValue> valueMap,
+        Map<String, List<String>> supplementaryData )
+    {
+        if ( arguments.size() < 3 )
+        {
+            throw new IllegalArgumentException( "At least three arguments required but found: " + arguments.size() );
         }
 
         // 1 = female, 0 = male
         float parameter;
         float weight;
-        byte gender = GENDER_CODES.contains(arguments.get(2)) ? (byte) 0 : (byte) 1;
+        byte gender = GENDER_CODES.contains( arguments.get( 2 ) ) ? (byte) 0 : (byte) 1;
 
         String zScore;
 
-        try {
-            parameter = Float.parseFloat(arguments.get(0));
-            weight = Float.parseFloat(arguments.get(1));
-        } catch (NumberFormatException ex) {
-            throw new IllegalArgumentException("Byte parsing failed");
+        try
+        {
+            parameter = Float.parseFloat( arguments.get( 0 ) );
+            weight = Float.parseFloat( arguments.get( 1 ) );
+        }
+        catch ( NumberFormatException ex )
+        {
+            throw new IllegalArgumentException( "Byte parsing failed" );
         }
 
-        zScore = getZScore(parameter, weight, gender);
+        zScore = getZScore( parameter, weight, gender );
 
         return zScore;
     }
@@ -79,40 +89,50 @@ public abstract class RuleFunctionZScore extends RuleFunction {
 
     public abstract Map<ZScoreTableKey, Map<Float, Integer>> getTableForBoy();
 
-    private String getZScore(float parameter, float weight, byte gender) {
-        ZScoreTableKey key = new ZScoreTableKey(gender, parameter);
+    private String getZScore( float parameter, float weight, byte gender )
+    {
+        ZScoreTableKey key = new ZScoreTableKey( gender, parameter );
 
         Map<Float, Integer> sdMap = new HashMap<>();
 
         // Female
-        if (gender == 1) {
-            sdMap = getTableForGirl().get(key);
-        } else {
+        if ( gender == 1 )
+        {
+            sdMap = getTableForGirl().get( key );
+        }
+        else
+        {
             Map<ZScoreTableKey, Map<Float, Integer>> test = getTableForBoy();
-            sdMap = getTableForBoy().get(key);
+            sdMap = getTableForBoy().get( key );
         }
 
-        int multiplicationFactor = getMultiplicationFactor(sdMap, weight);
+        int multiplicationFactor = getMultiplicationFactor( sdMap, weight );
 
         // weight exactly matches with any of the SD values
-        if (sdMap.keySet().contains(weight)) {
-            int sd = sdMap.get(weight);
+        if ( sdMap.keySet().contains( weight ) )
+        {
+            int sd = sdMap.get( weight );
 
-            return String.valueOf(sd * multiplicationFactor);
+            return String.valueOf( sd * multiplicationFactor );
         }
 
         // weight is beyond -3SD or 3SD
-        if (weight > Collections.max(sdMap.keySet())) {
-            return String.valueOf(3.5);
-        } else if (weight < Collections.min(sdMap.keySet())) {
-            return String.valueOf(-3.5);
+        if ( weight > Collections.max( sdMap.keySet() ) )
+        {
+            return String.valueOf( 3.5 );
+        }
+        else if ( weight < Collections.min( sdMap.keySet() ) )
+        {
+            return String.valueOf( -3.5 );
         }
 
         float lowerLimitX = 0, higherLimitY = 0;
 
         // find the interval
-        for (float f : sortKeySet(sdMap)) {
-            if (weight > f) {
+        for ( float f : sortKeySet( sdMap ) )
+        {
+            if ( weight > f )
+            {
                 lowerLimitX = f;
                 continue;
             }
@@ -129,46 +149,53 @@ public abstract class RuleFunctionZScore extends RuleFunction {
 
         float result;
 
-        if (weight > findMedian(sdMap)) {
+        if ( weight > findMedian( sdMap ) )
+        {
             gap = weight - lowerLimitX;
             decimalAddition = gap / distance;
-            result = sdMap.get(lowerLimitX) + decimalAddition;
-        } else {
+            result = sdMap.get( lowerLimitX ) + decimalAddition;
+        }
+        else
+        {
             gap = higherLimitY - weight;
             decimalAddition = gap / distance;
-            result = sdMap.get(higherLimitY) + decimalAddition;
+            result = sdMap.get( higherLimitY ) + decimalAddition;
         }
 
         result = result * multiplicationFactor;
 
-        return String.valueOf(getDecimalFormat().format(result));
+        return String.valueOf( getDecimalFormat().format( result ) );
     }
 
-    private int getMultiplicationFactor(Map<Float, Integer> sdMap, float weight) {
-        float median = findMedian(sdMap);
+    private int getMultiplicationFactor( Map<Float, Integer> sdMap, float weight )
+    {
+        float median = findMedian( sdMap );
 
-        return Float.compare(weight, median);
+        return Float.compare( weight, median );
     }
 
-    private float findMedian(Map<Float, Integer> sdMap) {
-        List<Float> sortedList = sortKeySet(sdMap);
+    private float findMedian( Map<Float, Integer> sdMap )
+    {
+        List<Float> sortedList = sortKeySet( sdMap );
 
-        return sortedList.get(3);
+        return sortedList.get( 3 );
     }
 
-    private List<Float> sortKeySet(Map<Float, Integer> sdMap) {
+    private List<Float> sortKeySet( Map<Float, Integer> sdMap )
+    {
         Set<Float> keySet = sdMap.keySet();
 
-        List<Float> list = new ArrayList<>(keySet);
+        List<Float> list = new ArrayList<>( keySet );
 
-        Collections.sort(list);
+        Collections.sort( list );
 
         return list;
     }
 
-    protected static DecimalFormat getDecimalFormat() {
+    protected static DecimalFormat getDecimalFormat()
+    {
         DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance();
-        decimalFormatSymbols.setDecimalSeparator('.');
-        return new DecimalFormat("###.00", decimalFormatSymbols);
+        decimalFormatSymbols.setDecimalSeparator( '.' );
+        return new DecimalFormat( "###.00", decimalFormatSymbols );
     }
 }

--- a/src/test/java/org/hisp/dhis/rules/RuleVariableValueBuilder.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleVariableValueBuilder.java
@@ -12,49 +12,51 @@ import javax.annotation.Nullable;
 public class RuleVariableValueBuilder
 {
 
-        private String value;
+    private String value;
 
-        private RuleValueType type = RuleValueType.TEXT;
+    private RuleValueType type = RuleValueType.TEXT;
 
-        private List<String> candidates = new ArrayList<>();
+    private List<String> candidates = new ArrayList<>();
 
-        private String eventDate;
+    private String eventDate;
 
-        public static RuleVariableValueBuilder create()
-        {
-                return new RuleVariableValueBuilder();
-        }
+    public static RuleVariableValueBuilder create()
+    {
+        return new RuleVariableValueBuilder();
+    }
 
-        public RuleVariableValueBuilder withValue( @Nonnull String value )
-        {
-                this.value = value;
+    public RuleVariableValueBuilder withValue( @Nonnull String value )
+    {
+        this.value = value;
 
-                return this;
-        }
+        return this;
+    }
 
-        public RuleVariableValueBuilder withCandidates( @Nonnull List<String> candidates )
-        {
-                this.candidates = candidates;
+    public RuleVariableValueBuilder withCandidates( @Nonnull List<String> candidates )
+    {
+        this.candidates = candidates;
 
-                return this;
-        }
-        public RuleVariableValueBuilder withEventDate( @Nullable String eventDate )
-        {
-                this.eventDate = eventDate;
+        return this;
+    }
 
-                return this;
-        }
-        public RuleVariableValueBuilder withType(@Nonnull RuleValueType valueType)
-        {
-                this.type = valueType;
+    public RuleVariableValueBuilder withEventDate( @Nullable String eventDate )
+    {
+        this.eventDate = eventDate;
 
-                return this;
-        }
+        return this;
+    }
 
-        public RuleVariableValue build()
-        {
-                RuleVariableValue ruleVariableValue = RuleVariableValue.create( value, type, candidates, eventDate );
+    public RuleVariableValueBuilder withType( @Nonnull RuleValueType valueType )
+    {
+        this.type = valueType;
 
-                return ruleVariableValue;
-        }
+        return this;
+    }
+
+    public RuleVariableValue build()
+    {
+        RuleVariableValue ruleVariableValue = RuleVariableValue.create( value, type, candidates, eventDate );
+
+        return ruleVariableValue;
+    }
 }

--- a/src/test/java/org/hisp/dhis/rules/RuleVariableValueBuilder.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleVariableValueBuilder.java
@@ -44,6 +44,12 @@ public class RuleVariableValueBuilder
 
                 return this;
         }
+        public RuleVariableValueBuilder withType(@Nonnull RuleValueType valueType)
+        {
+                this.type = valueType;
+
+                return this;
+        }
 
         public RuleVariableValue build()
         {

--- a/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValueTests.java
+++ b/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValueTests.java
@@ -50,202 +50,190 @@ import static org.hamcrest.CoreMatchers.is;
 @RunWith( JUnit4.class )
 public class RuleFunctionCountIfValueTests
 {
-        @Rule
-        public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-        private Map<String, RuleVariableValue> variableValues = new HashMap<>();
+    private Map<String, RuleVariableValue> variableValues = new HashMap<>();
 
-        @Test
-        public void return_zero_for_non_existing_variable()
-        {
-                RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
+    @Test
+    public void return_zero_for_non_existing_variable()
+    {
+        RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
 
-                variableValues = givenAEmptyVariableValues();
+        variableValues = givenAEmptyVariableValues();
 
-                MatcherAssert.assertThat( countIfValueFunction.evaluate(
-                    asList( "non existing variable", "value" ), variableValues, null ), is( "0" ) );
-        }
+        MatcherAssert.assertThat(
+            countIfValueFunction.evaluate( asList( "non existing variable", "value" ), variableValues, null ),
+            is( "0" ) );
+    }
 
-        @Ignore /*function throws error for empty value map*/
-        @Test
-        public void return_zero_for_for_empty_value_to_compare()
-        {
-                RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
+    @Ignore /* function throws error for empty value map */
+    @Test
+    public void return_zero_for_for_empty_value_to_compare()
+    {
+        RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
 
-                variableValues = givenAEmptyVariableValues();
+        variableValues = givenAEmptyVariableValues();
 
-                MatcherAssert.assertThat( countIfValueFunction.evaluate(
-                    asList( "var1", null ), variableValues, null ), is( "0" ) );
+        MatcherAssert.assertThat( countIfValueFunction.evaluate( asList( "var1", null ), variableValues, null ),
+            is( "0" ) );
 
-                MatcherAssert.assertThat( countIfValueFunction.evaluate(
-                    asList( "var1", "" ), variableValues, null ), is( "0" ) );
-        }
+        MatcherAssert.assertThat( countIfValueFunction.evaluate( asList( "var1", "" ), variableValues, null ),
+            is( "0" ) );
+    }
 
-        @Test
-        public void return_zero_for_variable_without_values()
-        {
-                RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
+    @Test
+    public void return_zero_for_variable_without_values()
+    {
+        RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
 
-                String variableName = "non_value_var";
+        String variableName = "non_value_var";
 
-                variableValues = givenAVariableValuesAndOneWithoutValue( variableName );
+        variableValues = givenAVariableValuesAndOneWithoutValue( variableName );
 
-                MatcherAssert.assertThat( countIfValueFunction.evaluate(
-                    asList( variableName, "valueToCompare" ), variableValues, null ), is( "0" ) );
-        }
+        MatcherAssert.assertThat(
+            countIfValueFunction.evaluate( asList( variableName, "valueToCompare" ), variableValues, null ),
+            is( "0" ) );
+    }
 
-        @Test
-        public void return_size_of_matched_values_for_variable_with_value_and_candidates()
-        {
-                RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
+    @Test
+    public void return_size_of_matched_values_for_variable_with_value_and_candidates()
+    {
+        RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
 
-                String variableName = "with_value_var";
-                String value = "valueA";
+        String variableName = "with_value_var";
+        String value = "valueA";
 
-                variableValues = givenAVariableValuesAndOneWithTwoExpectedCountCandidates(
-                    variableName, value );
+        variableValues = givenAVariableValuesAndOneWithTwoExpectedCountCandidates( variableName, value );
 
-                MatcherAssert.assertThat( countIfValueFunction.evaluate(
-                    asList( variableName, value ), variableValues, null ), is( "2" ) );
-        }
+        MatcherAssert.assertThat( countIfValueFunction.evaluate( asList( variableName, value ), variableValues, null ),
+            is( "2" ) );
+    }
 
-        @Test
-        public void return_zero_for_variable_with_no_matched_value_and_candidates()
-        {
-                RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
+    @Test
+    public void return_zero_for_variable_with_no_matched_value_and_candidates()
+    {
+        RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
 
-                String variableName = "with_value_var";
-                String value = "valueA";
+        String variableName = "with_value_var";
+        String value = "valueA";
 
-                variableValues = givenAVariableValuesAndOneWithTwoExpectedCountCandidates(
-                    variableName, value );
+        variableValues = givenAVariableValuesAndOneWithTwoExpectedCountCandidates( variableName, value );
 
-                MatcherAssert.assertThat( countIfValueFunction.evaluate(
-                    asList( variableName, "NoMatchedValue" ), variableValues, null ), is( "0" ) );
-        }
+        MatcherAssert.assertThat(
+            countIfValueFunction.evaluate( asList( variableName, "NoMatchedValue" ), variableValues, null ),
+            is( "0" ) );
+    }
 
-        @Test
-        public void return_zero_for_no_matched_variable_with_value_and_without_candidates()
-        {
-                RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
+    @Test
+    public void return_zero_for_no_matched_variable_with_value_and_without_candidates()
+    {
+        RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
 
-                String variableName = "with_value_var";
-                String value = "valueA";
+        String variableName = "with_value_var";
+        String value = "valueA";
 
-                variableValues = givenAVariableValuesAndOneWithUndefinedCandidates(
-                    variableName, value );
+        variableValues = givenAVariableValuesAndOneWithUndefinedCandidates( variableName, value );
 
-                MatcherAssert.assertThat( countIfValueFunction.evaluate(
-                    asList( variableName, "NoMatchedValue" ), variableValues, null ), is( "0" ) );
-        }
+        MatcherAssert.assertThat(
+            countIfValueFunction.evaluate( asList( variableName, "NoMatchedValue" ), variableValues, null ),
+            is( "0" ) );
+    }
 
+    @Test
+    public void support_numeric_values_in_expression_for_booleans()
+    {
+        RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
 
-        @Test
-        public void support_numeric_values_in_expression_for_booleans(){
-                RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
+        String variableName = "boolean_variable";
+        variableValues = givenVariableValueWithBooleanValues( variableName );
 
-                String variableName = "boolean_variable";
-                variableValues = givenVariableValueWithBooleanValues(variableName);
+        MatcherAssert.assertThat(
+            countIfValueFunction.evaluate( asList( "boolean_variable", "1" ), variableValues, null ), is( "2" ) );
 
-                MatcherAssert.assertThat(countIfValueFunction.evaluate(
-                        asList("boolean_variable","1"),variableValues,null), is("2"));
+        MatcherAssert.assertThat(
+            countIfValueFunction.evaluate( asList( "boolean_variable", "0" ), variableValues, null ), is( "1" ) );
+    }
 
-                MatcherAssert.assertThat(countIfValueFunction.evaluate(
-                        asList("boolean_variable","0"),variableValues,null), is("1"));
-        }
+    @Test
+    public void throw_illegal_argument_exception_when_variable_map_is_null()
+    {
+        thrown.expect( IllegalArgumentException.class );
+        RuleFunctionCountIfValue.create().evaluate( asList( "variable_name", "Value_to_compare" ), null, null );
+    }
 
-        @Test
-        public void throw_illegal_argument_exception_when_variable_map_is_null()
-        {
-                thrown.expect( IllegalArgumentException.class );
-                RuleFunctionCountIfValue.create().evaluate( asList( "variable_name", "Value_to_compare" ),
-                    null, null );
-        }
+    @Test
+    public void throw_illegal_argument_exception_when_argument_count_is_greater_than_expected()
+    {
+        thrown.expect( IllegalArgumentException.class );
+        RuleFunctionCountIfValue.create().evaluate( asList( "variable_name", "ded", "5" ), variableValues, null );
+    }
 
-        @Test
-        public void throw_illegal_argument_exception_when_argument_count_is_greater_than_expected()
-        {
-                thrown.expect( IllegalArgumentException.class );
-                RuleFunctionCountIfValue.create().evaluate( asList( "variable_name", "ded", "5" ),
-                    variableValues, null );
-        }
+    @Test
+    public void throw_illegal_argument_exception_when_arguments_count_is_lower_than_expected()
+    {
+        thrown.expect( IllegalArgumentException.class );
+        RuleFunctionCountIfValue.create().evaluate( asList( "variable_name" ), variableValues, null );
+    }
 
-        @Test
-        public void throw_illegal_argument_exception_when_arguments_count_is_lower_than_expected()
-        {
-                thrown.expect( IllegalArgumentException.class );
-                RuleFunctionCountIfValue.create().evaluate( asList( "variable_name" ), variableValues, null );
-        }
+    @Test
+    public void throw_illegal_argument_exception_when_arguments_is_empty()
+    {
+        thrown.expect( IllegalArgumentException.class );
+        RuleFunctionCountIfValue.create().evaluate( new ArrayList<String>(), variableValues, null );
+    }
 
-        @Test
-        public void throw_illegal_argument_exception_when_arguments_is_empty()
-        {
-                thrown.expect( IllegalArgumentException.class );
-                RuleFunctionCountIfValue.create().evaluate( new ArrayList<String>(), variableValues, null );
-        }
+    @Test
+    public void throw_null_pointer_exception_when_arguments_is_null()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleFunctionCountIfValue.create().evaluate( null, variableValues, null );
+    }
 
-        @Test
-        public void throw_null_pointer_exception_when_arguments_is_null()
-        {
-                thrown.expect( NullPointerException.class );
-                RuleFunctionCountIfValue.create().evaluate( null, variableValues, null );
-        }
+    private Map<String, RuleVariableValue> givenAEmptyVariableValues()
+    {
+        return new HashMap<>();
+    }
 
-        private Map<String, RuleVariableValue> givenAEmptyVariableValues()
-        {
-                return new HashMap<>();
-        }
+    private Map<String, RuleVariableValue> givenAVariableValuesAndOneWithoutValue( String variableNameWithoutValue )
+    {
+        variableValues.put( variableNameWithoutValue, null );
 
-        private Map<String, RuleVariableValue> givenAVariableValuesAndOneWithoutValue(
-            String variableNameWithoutValue )
-        {
-                variableValues.put( variableNameWithoutValue, null );
+        variableValues.put( "test_variable_two", RuleVariableValueBuilder.create().withValue( "Value two" ).build() );
 
-                variableValues.put( "test_variable_two",
-                    RuleVariableValueBuilder.create()
-                        .withValue( "Value two" )
-                        .build() );
+        return variableValues;
+    }
 
-                return variableValues;
-        }
+    private Map<String, RuleVariableValue> givenAVariableValuesAndOneWithTwoExpectedCountCandidates(
+        String variableNameWithValueAndCandidates, String valueToCompare )
+    {
+        variableValues.put( "test_variable_one", null );
 
-        private Map<String, RuleVariableValue> givenAVariableValuesAndOneWithTwoExpectedCountCandidates(
-            String variableNameWithValueAndCandidates, String valueToCompare )
-        {
-                variableValues.put( "test_variable_one", null );
+        variableValues.put( variableNameWithValueAndCandidates,
+            RuleVariableValueBuilder.create().withValue( valueToCompare )
+                .withCandidates( Arrays.asList( "one", valueToCompare, valueToCompare ) ).build() );
 
-                variableValues.put( variableNameWithValueAndCandidates,
-                    RuleVariableValueBuilder.create()
-                        .withValue( valueToCompare )
-                        .withCandidates( Arrays.asList( "one", valueToCompare, valueToCompare ) )
-                        .build() );
+        return variableValues;
+    }
 
-                return variableValues;
-        }
+    private Map<String, RuleVariableValue> givenAVariableValuesAndOneWithUndefinedCandidates(
+        String variableNameWithValueAndNonCandidates, String valueToCompare )
+    {
+        variableValues.put( "test_variable_one", null );
 
-        private Map<String, RuleVariableValue> givenAVariableValuesAndOneWithUndefinedCandidates(
-            String variableNameWithValueAndNonCandidates, String valueToCompare )
-        {
-                variableValues.put( "test_variable_one", null );
+        variableValues.put( variableNameWithValueAndNonCandidates,
+            RuleVariableValueBuilder.create().withValue( valueToCompare ).build() );
 
-                variableValues.put( variableNameWithValueAndNonCandidates,
-                    RuleVariableValueBuilder.create()
-                        .withValue( valueToCompare )
-                        .build() );
+        return variableValues;
+    }
 
-                return variableValues;
-        }
+    private Map<String, RuleVariableValue> givenVariableValueWithBooleanValues(
+        String variableNameWithValueAndNonCandidates )
+    {
+        variableValues.put( variableNameWithValueAndNonCandidates,
+            RuleVariableValueBuilder.create().withType( RuleValueType.BOOLEAN ).withValue( "true" )
+                .withCandidates( Arrays.asList( "false", "true", "true" ) ).build() );
 
-        private Map<String,RuleVariableValue> givenVariableValueWithBooleanValues(
-                String variableNameWithValueAndNonCandidates)
-        {
-                variableValues.put(variableNameWithValueAndNonCandidates,
-                        RuleVariableValueBuilder.create()
-                                .withType(RuleValueType.BOOLEAN)
-                                .withValue("true")
-                                .withCandidates(Arrays.asList("false","true","true" ))
-                                .build());
-
-                return variableValues;
-        }
+        return variableValues;
+    }
 }

--- a/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValueTests.java
+++ b/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionCountIfValueTests.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.rules.functions;
 import org.hamcrest.MatcherAssert;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.RuleVariableValueBuilder;
+import org.hisp.dhis.rules.models.RuleValueType;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -64,6 +66,7 @@ public class RuleFunctionCountIfValueTests
                     asList( "non existing variable", "value" ), variableValues, null ), is( "0" ) );
         }
 
+        @Ignore /*function throws error for empty value map*/
         @Test
         public void return_zero_for_for_empty_value_to_compare()
         {
@@ -134,6 +137,21 @@ public class RuleFunctionCountIfValueTests
 
                 MatcherAssert.assertThat( countIfValueFunction.evaluate(
                     asList( variableName, "NoMatchedValue" ), variableValues, null ), is( "0" ) );
+        }
+
+
+        @Test
+        public void support_numeric_values_in_expression_for_booleans(){
+                RuleFunction countIfValueFunction = RuleFunctionCountIfValue.create();
+
+                String variableName = "boolean_variable";
+                variableValues = givenVariableValueWithBooleanValues(variableName);
+
+                MatcherAssert.assertThat(countIfValueFunction.evaluate(
+                        asList("boolean_variable","1"),variableValues,null), is("2"));
+
+                MatcherAssert.assertThat(countIfValueFunction.evaluate(
+                        asList("boolean_variable","0"),variableValues,null), is("1"));
         }
 
         @Test
@@ -214,6 +232,19 @@ public class RuleFunctionCountIfValueTests
                     RuleVariableValueBuilder.create()
                         .withValue( valueToCompare )
                         .build() );
+
+                return variableValues;
+        }
+
+        private Map<String,RuleVariableValue> givenVariableValueWithBooleanValues(
+                String variableNameWithValueAndNonCandidates)
+        {
+                variableValues.put(variableNameWithValueAndNonCandidates,
+                        RuleVariableValueBuilder.create()
+                                .withType(RuleValueType.BOOLEAN)
+                                .withValue("true")
+                                .withCandidates(Arrays.asList("false","true","true" ))
+                                .build());
 
                 return variableValues;
         }

--- a/src/test/java/org/hisp/dhis/rules/models/RuleEnrollmentTests.java
+++ b/src/test/java/org/hisp/dhis/rules/models/RuleEnrollmentTests.java
@@ -24,7 +24,7 @@ public class RuleEnrollmentTests
         @Test
         public void createShouldThrowOnNullEnrollment()
         {
-                thrown.expect( IllegalStateException.class );
+                thrown.expect( NullPointerException.class );
                 RuleEnrollment.create( null, new Date(), new Date(),
                     RuleEnrollment.Status.ACTIVE, null,null, new ArrayList<RuleAttributeValue>(), "");
         }
@@ -32,7 +32,7 @@ public class RuleEnrollmentTests
         @Test
         public void createShouldThrowOnNullIncidentDate()
         {
-                thrown.expect( IllegalStateException.class );
+                thrown.expect( NullPointerException.class );
                 RuleEnrollment.create("test_enrollment", null, new Date(),
                         RuleEnrollment.Status.ACTIVE, null, null, new ArrayList<RuleAttributeValue>(), "");
 
@@ -41,7 +41,7 @@ public class RuleEnrollmentTests
         @Test
         public void createShouldThrowOnNullEnrollmentDate()
         {
-                thrown.expect( IllegalStateException.class );
+                thrown.expect( NullPointerException.class );
                 RuleEnrollment.create( "test_enrollment", new Date(), null,
                         RuleEnrollment.Status.ACTIVE,null,null, new ArrayList<RuleAttributeValue>(), "");
         }
@@ -49,7 +49,7 @@ public class RuleEnrollmentTests
         @Test
         public void createShouldThrowOnNullStatus()
         {
-                thrown.expect( IllegalStateException.class );
+                thrown.expect( NullPointerException.class );
                 RuleEnrollment.create( "test_enrollment", new Date(), new Date(),
                     null, null,null,new ArrayList<RuleAttributeValue>(), "");
         }

--- a/src/test/java/org/hisp/dhis/rules/models/RuleEnrollmentTests.java
+++ b/src/test/java/org/hisp/dhis/rules/models/RuleEnrollmentTests.java
@@ -18,103 +18,103 @@ import static org.mockito.Mockito.mock;
 @RunWith( JUnit4.class )
 public class RuleEnrollmentTests
 {
-        @Rule
-        public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-        @Test
-        public void createShouldThrowOnNullEnrollment()
+    @Test
+    public void createShouldThrowOnNullEnrollment()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEnrollment.create( null, new Date(), new Date(), RuleEnrollment.Status.ACTIVE, null, null,
+            new ArrayList<RuleAttributeValue>(), "" );
+    }
+
+    @Test
+    public void createShouldThrowOnNullIncidentDate()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEnrollment.create( "test_enrollment", null, new Date(), RuleEnrollment.Status.ACTIVE, null, null,
+            new ArrayList<RuleAttributeValue>(), "" );
+
+    }
+
+    @Test
+    public void createShouldThrowOnNullEnrollmentDate()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEnrollment.create( "test_enrollment", new Date(), null, RuleEnrollment.Status.ACTIVE, null, null,
+            new ArrayList<RuleAttributeValue>(), "" );
+    }
+
+    @Test
+    public void createShouldThrowOnNullStatus()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEnrollment.create( "test_enrollment", new Date(), new Date(), null, null, null,
+            new ArrayList<RuleAttributeValue>(), "" );
+    }
+
+    @Test
+    public void createShouldThrowOnNullValueList()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEnrollment.create( "test_enrollment", new Date(), new Date(), RuleEnrollment.Status.ACTIVE, null, null,
+            null, "" );
+    }
+
+    @Test
+    public void createShouldPropagatePropertiesCorrectly()
+    {
+        RuleAttributeValue ruleAttributeValueOne = mock( RuleAttributeValue.class );
+        RuleAttributeValue ruleAttributeValueTwo = mock( RuleAttributeValue.class );
+        RuleAttributeValue ruleAttributeValueThree = mock( RuleAttributeValue.class );
+
+        Date incidentDate = new Date();
+        Date enrollmentDate = new Date();
+
+        RuleEnrollment ruleEnrollment = RuleEnrollment.create( "test_enrollment", incidentDate, enrollmentDate,
+            RuleEnrollment.Status.ACTIVE, "", "",
+            Arrays.asList( ruleAttributeValueOne, ruleAttributeValueTwo, ruleAttributeValueThree ), "" );
+
+        assertThat( ruleEnrollment.enrollment() ).isEqualTo( "test_enrollment" );
+        assertThat( ruleEnrollment.incidentDate() ).isEqualTo( incidentDate );
+        assertThat( ruleEnrollment.enrollmentDate() ).isEqualTo( enrollmentDate );
+        assertThat( ruleEnrollment.status() ).isEqualTo( RuleEnrollment.Status.ACTIVE );
+        assertThat( ruleEnrollment.attributeValues().size() ).isEqualTo( 3 );
+        assertThat( ruleEnrollment.attributeValues().get( 0 ) ).isEqualTo( ruleAttributeValueOne );
+        assertThat( ruleEnrollment.attributeValues().get( 1 ) ).isEqualTo( ruleAttributeValueTwo );
+        assertThat( ruleEnrollment.attributeValues().get( 2 ) ).isEqualTo( ruleAttributeValueThree );
+    }
+
+    @Test
+    public void createShouldReturnImmutableList()
+    {
+        RuleAttributeValue ruleAttributeValueOne = mock( RuleAttributeValue.class );
+        RuleAttributeValue ruleAttributeValueTwo = mock( RuleAttributeValue.class );
+        RuleAttributeValue ruleAttributeValueThree = mock( RuleAttributeValue.class );
+
+        List<RuleAttributeValue> attributeValues = new ArrayList<>();
+        attributeValues.add( ruleAttributeValueOne );
+        attributeValues.add( ruleAttributeValueTwo );
+
+        RuleEnrollment ruleEnrollment = RuleEnrollment.create( "test_enrollment", new Date(), new Date(),
+            RuleEnrollment.Status.ACTIVE, "", null, attributeValues, "" );
+
+        // mutating source array
+        attributeValues.add( ruleAttributeValueThree );
+
+        assertThat( ruleEnrollment.attributeValues().size() ).isEqualTo( 3 );
+        assertThat( ruleEnrollment.attributeValues().get( 0 ) ).isEqualTo( ruleAttributeValueOne );
+        assertThat( ruleEnrollment.attributeValues().get( 1 ) ).isEqualTo( ruleAttributeValueTwo );
+
+        try
         {
-                thrown.expect( NullPointerException.class );
-                RuleEnrollment.create( null, new Date(), new Date(),
-                    RuleEnrollment.Status.ACTIVE, null,null, new ArrayList<RuleAttributeValue>(), "");
+            ruleEnrollment.attributeValues().clear();
+            fail( "UnsupportedOperationException was expected, but nothing was thrown." );
         }
-
-        @Test
-        public void createShouldThrowOnNullIncidentDate()
+        catch ( UnsupportedOperationException unsupportedOperationException )
         {
-                thrown.expect( NullPointerException.class );
-                RuleEnrollment.create("test_enrollment", null, new Date(),
-                        RuleEnrollment.Status.ACTIVE, null, null, new ArrayList<RuleAttributeValue>(), "");
-
+            // noop
         }
-
-        @Test
-        public void createShouldThrowOnNullEnrollmentDate()
-        {
-                thrown.expect( NullPointerException.class );
-                RuleEnrollment.create( "test_enrollment", new Date(), null,
-                        RuleEnrollment.Status.ACTIVE,null,null, new ArrayList<RuleAttributeValue>(), "");
-        }
-
-        @Test
-        public void createShouldThrowOnNullStatus()
-        {
-                thrown.expect( NullPointerException.class );
-                RuleEnrollment.create( "test_enrollment", new Date(), new Date(),
-                    null, null,null,new ArrayList<RuleAttributeValue>(), "");
-        }
-
-        @Test
-        public void createShouldThrowOnNullValueList()
-        {
-                thrown.expect( NullPointerException.class );
-                RuleEnrollment.create( "test_enrollment", new Date(), new Date(),
-                    RuleEnrollment.Status.ACTIVE, null,null,null, "");
-        }
-
-        @Test
-        public void createShouldPropagatePropertiesCorrectly()
-        {
-                RuleAttributeValue ruleAttributeValueOne = mock( RuleAttributeValue.class );
-                RuleAttributeValue ruleAttributeValueTwo = mock( RuleAttributeValue.class );
-                RuleAttributeValue ruleAttributeValueThree = mock( RuleAttributeValue.class );
-
-                Date incidentDate = new Date();
-                Date enrollmentDate = new Date();
-
-                RuleEnrollment ruleEnrollment = RuleEnrollment.create( "test_enrollment",
-                    incidentDate, enrollmentDate, RuleEnrollment.Status.ACTIVE, "", "",
-                    Arrays.asList( ruleAttributeValueOne, ruleAttributeValueTwo, ruleAttributeValueThree ), "");
-
-                assertThat( ruleEnrollment.enrollment() ).isEqualTo( "test_enrollment" );
-                assertThat( ruleEnrollment.incidentDate() ).isEqualTo( incidentDate );
-                assertThat( ruleEnrollment.enrollmentDate() ).isEqualTo( enrollmentDate );
-                assertThat( ruleEnrollment.status() ).isEqualTo( RuleEnrollment.Status.ACTIVE );
-                assertThat( ruleEnrollment.attributeValues().size() ).isEqualTo( 3 );
-                assertThat( ruleEnrollment.attributeValues().get( 0 ) ).isEqualTo( ruleAttributeValueOne );
-                assertThat( ruleEnrollment.attributeValues().get( 1 ) ).isEqualTo( ruleAttributeValueTwo );
-                assertThat( ruleEnrollment.attributeValues().get( 2 ) ).isEqualTo( ruleAttributeValueThree );
-        }
-
-        @Test
-        public void createShouldReturnImmutableList()
-        {
-                RuleAttributeValue ruleAttributeValueOne = mock( RuleAttributeValue.class );
-                RuleAttributeValue ruleAttributeValueTwo = mock( RuleAttributeValue.class );
-                RuleAttributeValue ruleAttributeValueThree = mock( RuleAttributeValue.class );
-
-                List<RuleAttributeValue> attributeValues = new ArrayList<>();
-                attributeValues.add( ruleAttributeValueOne );
-                attributeValues.add( ruleAttributeValueTwo );
-
-                RuleEnrollment ruleEnrollment = RuleEnrollment.create( "test_enrollment",
-                    new Date(), new Date(), RuleEnrollment.Status.ACTIVE, "", null,attributeValues, "");
-
-                // mutating source array
-                attributeValues.add( ruleAttributeValueThree );
-
-                assertThat( ruleEnrollment.attributeValues().size() ).isEqualTo( 3 );
-                assertThat( ruleEnrollment.attributeValues().get( 0 ) ).isEqualTo( ruleAttributeValueOne );
-                assertThat( ruleEnrollment.attributeValues().get( 1 ) ).isEqualTo( ruleAttributeValueTwo );
-
-                try
-                {
-                        ruleEnrollment.attributeValues().clear();
-                        fail( "UnsupportedOperationException was expected, but nothing was thrown." );
-                }
-                catch ( UnsupportedOperationException unsupportedOperationException )
-                {
-                        // noop
-                }
-        }
+    }
 }

--- a/src/test/java/org/hisp/dhis/rules/models/RuleEventTests.java
+++ b/src/test/java/org/hisp/dhis/rules/models/RuleEventTests.java
@@ -17,129 +17,129 @@ import static org.mockito.Mockito.mock;
 @RunWith( JUnit4.class )
 public class RuleEventTests
 {
-        private static final String DATE_PATTERN = "yyyy-MM-dd";
+    private static final String DATE_PATTERN = "yyyy-MM-dd";
 
-        @Rule
-        public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-        @Test
-        public void createShouldThrowExceptionIfEventIsNull()
+    @Test
+    public void createShouldThrowExceptionIfEventIsNull()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEvent.create( null, "test_programstage", RuleEvent.Status.ACTIVE, new Date(), new Date(), null, null,
+            Arrays.<RuleDataValue> asList(), "" );
+    }
+
+    @Test
+    public void createShouldThrowExceptionIfProgramStageIsNull()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEvent.create( "test_event", null, RuleEvent.Status.ACTIVE, new Date(), new Date(), null, null,
+            Arrays.<RuleDataValue> asList(), "" );
+    }
+
+    @Test
+    public void createShouldThrowExceptionIfStatusIsNull()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEvent.create( "test_event", "test_programstage", null, new Date(), new Date(), null, null,
+            Arrays.<RuleDataValue> asList(), "" );
+    }
+
+    @Test
+    public void createShouldThrowExceptionIfEventDateIsNull()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEvent.create( "test_event", "test_programstage", RuleEvent.Status.ACTIVE, null, new Date(), null, null,
+            Arrays.<RuleDataValue> asList(), "" );
+    }
+
+    @Test
+    public void createShouldThrowExceptionIfDueDateIsNull()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEvent.create( "test_event", "test_programstage", RuleEvent.Status.ACTIVE, new Date(), null, null, null,
+            Arrays.<RuleDataValue> asList(), "" );
+
+    }
+
+    @Test
+    public void createShouldThrowExceptionIfListOfDataValuesIsNull()
+    {
+        thrown.expect( NullPointerException.class );
+        RuleEvent.create( "test_event", "test_programstage", RuleEvent.Status.ACTIVE, new Date(), new Date(), null,
+            null, null, "" );
+
+    }
+
+    @Test
+    public void createShouldPropagateImmutableList()
+    {
+        RuleDataValue ruleDataValue = mock( RuleDataValue.class );
+
+        List<RuleDataValue> ruleDataValues = new ArrayList<>();
+        ruleDataValues.add( ruleDataValue );
+
+        RuleEvent ruleEvent = RuleEvent.create( "test_event_uid", "test_stage_uid", RuleEvent.Status.ACTIVE, new Date(),
+            new Date(), "", "", ruleDataValues, "" );
+
+        // add another data value
+        ruleDataValues.add( ruleDataValue );
+
+        assertThat( ruleEvent.dataValues().size() ).isEqualTo( 1 );
+        assertThat( ruleEvent.dataValues().get( 0 ) ).isEqualTo( ruleDataValue );
+
+        try
         {
-                thrown.expect( NullPointerException.class );
-                RuleEvent.create( null, "test_programstage", RuleEvent.Status.ACTIVE,
-                        new Date(), new Date(), null,null,Arrays.<RuleDataValue>asList(), "");
+            ruleEvent.dataValues().add( ruleDataValue );
+            fail( "UnsupportedOperationException was expected, but nothing was thrown" );
         }
-
-        @Test
-        public void createShouldThrowExceptionIfProgramStageIsNull()
+        catch ( UnsupportedOperationException exception )
         {
-                thrown.expect( NullPointerException.class );
-                RuleEvent.create( "test_event", null, RuleEvent.Status.ACTIVE,
-                        new Date(), new Date(), null,null,Arrays.<RuleDataValue>asList(), "");
+            // noop
         }
+    }
 
-        @Test
-        public void createShouldThrowExceptionIfStatusIsNull()
-        {
-                thrown.expect( NullPointerException.class );
-                RuleEvent.create( "test_event", "test_programstage", null,
-                        new Date(), new Date(), null,null,Arrays.<RuleDataValue>asList(), "");
-        }
+    @Test
+    public void createShouldPropagateValuesCorrectly()
+    {
+        RuleDataValue ruleDataValue = mock( RuleDataValue.class );
 
-        @Test
-        public void createShouldThrowExceptionIfEventDateIsNull()
-        {
-                thrown.expect( NullPointerException.class );
-                RuleEvent.create( "test_event", "test_programstage", RuleEvent.Status.ACTIVE,
-                        null, new Date(), null,null,Arrays.<RuleDataValue>asList(), "");
-        }
+        List<RuleDataValue> ruleDataValues = new ArrayList<>();
+        ruleDataValues.add( ruleDataValue );
 
-        @Test
-        public void createShouldThrowExceptionIfDueDateIsNull()
-        {
-                thrown.expect( NullPointerException.class );
-                RuleEvent.create( "test_event", "test_programstage", RuleEvent.Status.ACTIVE,
-                    new Date(), null, null,null,Arrays.<RuleDataValue>asList(), "");
+        Date eventDate = new Date();
+        Date dueDate = new Date();
 
-        }
+        RuleEvent ruleEvent = RuleEvent.create( "test_event_uid", "test_stage_uid", RuleEvent.Status.ACTIVE, eventDate,
+            dueDate, "", "", ruleDataValues, "" );
 
-        @Test
-        public void createShouldThrowExceptionIfListOfDataValuesIsNull()
-        {
-                thrown.expect( NullPointerException.class );
-                RuleEvent.create( "test_event", "test_programstage", RuleEvent.Status.ACTIVE, new Date(), new Date(),
-                        null, null,null, "");
+        assertThat( ruleEvent.event() ).isEqualTo( "test_event_uid" );
+        assertThat( ruleEvent.status() ).isEqualTo( RuleEvent.Status.ACTIVE );
+        assertThat( ruleEvent.programStage() ).isEqualTo( "test_stage_uid" );
+        assertThat( ruleEvent.eventDate() ).isEqualTo( eventDate );
+        assertThat( ruleEvent.dueDate() ).isEqualTo( dueDate );
 
-        }
+        assertThat( ruleEvent.dataValues().size() ).isEqualTo( 1 );
+        assertThat( ruleEvent.dataValues().get( 0 ) ).isEqualTo( ruleDataValue );
+    }
 
-        @Test
-        public void createShouldPropagateImmutableList()
-        {
-                RuleDataValue ruleDataValue = mock( RuleDataValue.class );
+    @Test
+    public void eventDateComparatorTest()
+        throws ParseException
+    {
+        SimpleDateFormat dateFormat = new SimpleDateFormat( DATE_PATTERN, Locale.US );
+        List<RuleEvent> ruleEvents = Arrays.asList(
+            RuleEvent.create( "test_event_one", "test_program_stage_one", RuleEvent.Status.ACTIVE,
+                dateFormat.parse( "2014-02-11" ), dateFormat.parse( "2014-02-11" ), "", null,
+                new ArrayList<RuleDataValue>(), "" ),
+            RuleEvent.create( "test_event_two", "test_program_stage_two", RuleEvent.Status.ACTIVE,
+                dateFormat.parse( "2017-03-22" ), dateFormat.parse( "2017-03-22" ), "", null,
+                new ArrayList<RuleDataValue>(), "" ) );
 
-                List<RuleDataValue> ruleDataValues = new ArrayList<>();
-                ruleDataValues.add( ruleDataValue );
+        Collections.sort( ruleEvents, RuleEvent.EVENT_DATE_COMPARATOR );
 
-                RuleEvent ruleEvent = RuleEvent.create( "test_event_uid", "test_stage_uid",
-                    RuleEvent.Status.ACTIVE, new Date(), new Date(), "", "", ruleDataValues, "");
-
-                // add another data value
-                ruleDataValues.add( ruleDataValue );
-
-                assertThat( ruleEvent.dataValues().size() ).isEqualTo( 1 );
-                assertThat( ruleEvent.dataValues().get( 0 ) ).isEqualTo( ruleDataValue );
-
-                try
-                {
-                        ruleEvent.dataValues().add( ruleDataValue );
-                        fail( "UnsupportedOperationException was expected, but nothing was thrown" );
-                }
-                catch ( UnsupportedOperationException exception )
-                {
-                        // noop
-                }
-        }
-
-        @Test
-        public void createShouldPropagateValuesCorrectly()
-        {
-                RuleDataValue ruleDataValue = mock( RuleDataValue.class );
-
-                List<RuleDataValue> ruleDataValues = new ArrayList<>();
-                ruleDataValues.add( ruleDataValue );
-
-                Date eventDate = new Date();
-                Date dueDate = new Date();
-
-                RuleEvent ruleEvent = RuleEvent.create( "test_event_uid", "test_stage_uid",
-                    RuleEvent.Status.ACTIVE, eventDate, dueDate, "","",ruleDataValues, "");
-
-                assertThat( ruleEvent.event() ).isEqualTo( "test_event_uid" );
-                assertThat( ruleEvent.status() ).isEqualTo( RuleEvent.Status.ACTIVE );
-                assertThat( ruleEvent.programStage() ).isEqualTo( "test_stage_uid" );
-                assertThat( ruleEvent.eventDate() ).isEqualTo( eventDate );
-                assertThat( ruleEvent.dueDate() ).isEqualTo( dueDate );
-
-                assertThat( ruleEvent.dataValues().size() ).isEqualTo( 1 );
-                assertThat( ruleEvent.dataValues().get( 0 ) ).isEqualTo( ruleDataValue );
-        }
-
-        @Test
-        public void eventDateComparatorTest()
-            throws ParseException
-        {
-                SimpleDateFormat dateFormat = new SimpleDateFormat( DATE_PATTERN, Locale.US );
-                List<RuleEvent> ruleEvents = Arrays.asList(
-                    RuleEvent.create( "test_event_one", "test_program_stage_one", RuleEvent.Status.ACTIVE,
-                        dateFormat.parse( "2014-02-11" ), dateFormat.parse( "2014-02-11" ),"",null,
-                        new ArrayList<RuleDataValue>(), ""),
-                    RuleEvent.create( "test_event_two", "test_program_stage_two", RuleEvent.Status.ACTIVE,
-                        dateFormat.parse( "2017-03-22" ), dateFormat.parse( "2017-03-22" ), "",null,
-                        new ArrayList<RuleDataValue>(), "") );
-
-                Collections.sort( ruleEvents, RuleEvent.EVENT_DATE_COMPARATOR );
-
-                assertThat( ruleEvents.get( 0 ).event() ).isEqualTo( "test_event_two" );
-                assertThat( ruleEvents.get( 1 ).event() ).isEqualTo( "test_event_one" );
-        }
+        assertThat( ruleEvents.get( 0 ).event() ).isEqualTo( "test_event_two" );
+        assertThat( ruleEvents.get( 1 ).event() ).isEqualTo( "test_event_one" );
+    }
 }

--- a/src/test/java/org/hisp/dhis/rules/models/RuleEventTests.java
+++ b/src/test/java/org/hisp/dhis/rules/models/RuleEventTests.java
@@ -25,7 +25,7 @@ public class RuleEventTests
         @Test
         public void createShouldThrowExceptionIfEventIsNull()
         {
-                thrown.expect( IllegalStateException.class );
+                thrown.expect( NullPointerException.class );
                 RuleEvent.create( null, "test_programstage", RuleEvent.Status.ACTIVE,
                         new Date(), new Date(), null,null,Arrays.<RuleDataValue>asList(), "");
         }
@@ -33,7 +33,7 @@ public class RuleEventTests
         @Test
         public void createShouldThrowExceptionIfProgramStageIsNull()
         {
-                thrown.expect( IllegalStateException.class );
+                thrown.expect( NullPointerException.class );
                 RuleEvent.create( "test_event", null, RuleEvent.Status.ACTIVE,
                         new Date(), new Date(), null,null,Arrays.<RuleDataValue>asList(), "");
         }
@@ -41,7 +41,7 @@ public class RuleEventTests
         @Test
         public void createShouldThrowExceptionIfStatusIsNull()
         {
-                thrown.expect( IllegalStateException.class );
+                thrown.expect( NullPointerException.class );
                 RuleEvent.create( "test_event", "test_programstage", null,
                         new Date(), new Date(), null,null,Arrays.<RuleDataValue>asList(), "");
         }
@@ -49,7 +49,7 @@ public class RuleEventTests
         @Test
         public void createShouldThrowExceptionIfEventDateIsNull()
         {
-                thrown.expect( IllegalStateException.class );
+                thrown.expect( NullPointerException.class );
                 RuleEvent.create( "test_event", "test_programstage", RuleEvent.Status.ACTIVE,
                         null, new Date(), null,null,Arrays.<RuleDataValue>asList(), "");
         }
@@ -57,7 +57,7 @@ public class RuleEventTests
         @Test
         public void createShouldThrowExceptionIfDueDateIsNull()
         {
-                thrown.expect( IllegalStateException.class );
+                thrown.expect( NullPointerException.class );
                 RuleEvent.create( "test_event", "test_programstage", RuleEvent.Status.ACTIVE,
                     new Date(), null, null,null,Arrays.<RuleDataValue>asList(), "");
 


### PR DESCRIPTION
Having `#{boolean_variable}` with boolean type, the expression `d2:countIfValue('variable_name','1')` did not evaluate properly as all boolean values as stored as "true"/"false"

- Support for numeric values 1 and 0 to be used with d2 function in rule expression
- Fixed some test: Added DecimalFormat method to get correct decimal point in ZScore
