### PR TITLE
fix: use java7 in travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: java
 sudo : false
-dist : trusty
+dist : precise
 jdk:
-- openjdk8
+- openjdk7
 addons:
   apt:
     packages:
-    - oracle-java8-installer
+    - oracle-java7-installer
 before_install:
 - rm ~/.m2/settings.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: java
 sudo : false
-dist : bionic
+dist : trusty
 jdk:
 - openjdk7
 addons:
   apt:
     packages:
-    - oracle-java7-installer
+    - oracle-java8-installer
 before_install:
 - rm ~/.m2/settings.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo : false
-dist : trusty
+dist : precise
 jdk:
 - openjdk7
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo : false
-dist : precise
+dist : trusty
 jdk:
 - openjdk7
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo : false
-dist : precise
+dist : xenial
 jdk:
 - openjdk7
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo : false
-dist : xenial
+dist : bionic
 jdk:
 - openjdk7
 addons:


### PR DESCRIPTION
Forcing travis to use java 7 (android api < 24)