### PR TITLE
feat: Updated parser version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
         <dependency>
             <groupId>org.hisp.dhis.parser</groupId>
             <artifactId>dhis-antlr-expression-parser</artifactId>
-            <version>1.0.6</version>
+            <version>1.0.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/hisp/dhis/rules/RuleEngineExecution.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleEngineExecution.java
@@ -168,8 +168,16 @@ class RuleEngineExecution
             .validateCommonProperties();
 
 
-        return Parser.visit( condition, commonExpressionVisitor ).toString();
+        return Parser.visit( condition, commonExpressionVisitor, !isOldAndroidVersion() ).toString();
 
+    }
+
+    private Boolean isOldAndroidVersion()
+    {
+        return valueMap.containsKey( "environment" ) &&
+                Objects.equals( valueMap.get( "environment" ).value(), TriggerEnvironment.ANDROIDCLIENT.getClientName() ) &&
+                supplementaryData.containsKey( "android_version" ) &&
+                Integer.parseInt( supplementaryData.get( "android_version" ).get( 0 ) ) < 21;
     }
 
     private Boolean isAssignToCalculatedValue( RuleAction ruleAction )


### PR DESCRIPTION
The parser has been updated to 1.0.7-SNAPSHOT in order to fix problems with android 4.4.
In the rule engine, a new method has been added to check if the trigger environment is an Android client and if so checks in the supplementary data if the current Android Version is less than Lollipop.