### PR TITLE
fix: Update parser version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
         <dependency>
             <groupId>org.hisp.dhis.parser</groupId>
             <artifactId>dhis-antlr-expression-parser</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The android app build is failing when trying to download the parser library as the version in the pom file is pointing to version 1.0.7 instead of 1.0.7-SNAPSHOT