### PR TITLE
fix: update parser version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
         <dependency>
             <groupId>org.hisp.dhis.parser</groupId>
             <artifactId>dhis-antlr-expression-parser</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Android app build was failing because the pom file was pointing to version 1.0.7 of the parser when the correct one is 1.0.7-SNAPSHOT.