### PR TITLE
fix: Calculated value assignment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.8-SNAPSHOT</version>
+    <version>2.0.9-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/src/main/java/org/hisp/dhis/rules/RuleEngineExecution.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleEngineExecution.java
@@ -135,7 +135,10 @@ class RuleEngineExecution
                         if ( isAssignToCalculatedValue( action ) )
                         {
                             RuleActionAssign ruleActionAssign = (RuleActionAssign) action;
-                            updateValueMap( ruleActionAssign.content(), RuleVariableValue.create( process( ruleActionAssign.data() ), RuleValueType.TEXT ) );
+                            updateValueMap(
+                                    Utils.unwrapVariableName( ruleActionAssign.content() ),
+                                    RuleVariableValue.create( process( ruleActionAssign.data() ), RuleValueType.TEXT )
+                            );
                         }
                         else
                         {

--- a/src/main/java/org/hisp/dhis/rules/Utils.java
+++ b/src/main/java/org/hisp/dhis/rules/Utils.java
@@ -5,11 +5,17 @@ import org.hisp.dhis.rules.models.RuleEvent;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
 
 public final class Utils
 {
 
     public static final SimpleDateFormat dateFormat = new SimpleDateFormat( "yyyy-MM-dd", Locale.US );
+    static final String VARIABLE_PATTERN = "[#]\\{([\\w -_.]+)\\}";
+    static final Pattern VARIABLE_PATTERN_COMPILED = Pattern.compile( VARIABLE_PATTERN );
 
     private Utils()
     {
@@ -53,5 +59,19 @@ public final class Utils
             }
         }
         return dateFormat.format( Collections.max( dates ) );
+    }
+
+    @Nonnull
+    static String unwrapVariableName( @Nonnull String variable )
+    {
+        Matcher variableNameMatcher = VARIABLE_PATTERN_COMPILED.matcher( variable );
+
+        // extract variable name
+        if ( variableNameMatcher.find() )
+        {
+            return variableNameMatcher.group( 1 );
+        }
+
+        throw new IllegalArgumentException( "Malformed variable: " + variable );
     }
 }

--- a/src/test/java/org/hisp/dhis/rules/ConstantsValueTests.java
+++ b/src/test/java/org/hisp/dhis/rules/ConstantsValueTests.java
@@ -130,7 +130,7 @@ public class ConstantsValueTests
     public void assignValueThroughVariable()
         throws Exception
     {
-        RuleAction assignAction = RuleActionAssign.create( "test_attribute", "4", null );
+        RuleAction assignAction = RuleActionAssign.create( "#{test_attribute}", "4", null );
         RuleAction action = RuleActionShowError.create( null, "#{test_attribute}", "" );
         org.hisp.dhis.rules.models.Rule rule = org.hisp.dhis.rules.models.Rule
             .create( null, 1, "true", Arrays.asList( assignAction ), "test_program_rule1" );

--- a/src/test/java/org/hisp/dhis/rules/models/CalculatedValueTests.java
+++ b/src/test/java/org/hisp/dhis/rules/models/CalculatedValueTests.java
@@ -95,7 +95,7 @@ public class CalculatedValueTests
     public void sendMessageMustGetValueFromAssignAction()
         throws Exception
     {
-        RuleAction assignAction = RuleActionAssign.create( "test_calculated_value", "2+2", null );
+        RuleAction assignAction = RuleActionAssign.create( "#{test_calculated_value}", "2+2", null );
         org.hisp.dhis.rules.models.Rule rule = org.hisp.dhis.rules.models.Rule
             .create( null, 1, "true", Arrays.asList( assignAction ), "test_program_rule1" );
 
@@ -137,7 +137,7 @@ public class CalculatedValueTests
     private List<org.hisp.dhis.rules.models.Rule> createRules( int i )
     {
         ArrayList<org.hisp.dhis.rules.models.Rule> rules = Lists.newArrayList();
-        RuleAction assignAction = RuleActionAssign.create( "test_calculated_value", "2+2", null );
+        RuleAction assignAction = RuleActionAssign.create( "#{test_calculated_value}", "2+2", null );
         org.hisp.dhis.rules.models.Rule rule = org.hisp.dhis.rules.models.Rule
             .create( null, 1, "true", Arrays.asList( assignAction ), "test_program_rule1" );
 
@@ -156,7 +156,7 @@ public class CalculatedValueTests
     public void sendMessageMustGetValueFromAssignActionInSingleExecution()
         throws Exception
     {
-        RuleAction assignAction = RuleActionAssign.create( "test_calculated_value", "2+2", null );
+        RuleAction assignAction = RuleActionAssign.create( "#{test_calculated_value}", "2+2", null );
         org.hisp.dhis.rules.models.Rule rule = org.hisp.dhis.rules.models.Rule
             .create( null, 1, "true", Arrays.asList( assignAction ), "test_program_rule1" );
 


### PR DESCRIPTION
When a rule action was assigning a value to a calculated value variable, the value map was being updated with the wrong key.