### PR TITLE
fix: Allow nullable data for RuleEffect factory method

### DIFF
--- a/src/main/java/org/hisp/dhis/rules/models/RuleEffect.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleEffect.java
@@ -3,13 +3,14 @@ package org.hisp.dhis.rules.models;
 import com.google.auto.value.AutoValue;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class RuleEffect
 {
 
     @Nonnull
-    public static RuleEffect create( @Nonnull RuleAction ruleAction, @Nonnull String data )
+    public static RuleEffect create( @Nonnull RuleAction ruleAction, @Nullable String data )
     {
         return new AutoValue_RuleEffect( ruleAction, data );
     }


### PR DESCRIPTION
When using RuleEffectSendMessage then we do not need `data` field in `RuleEffect` object. So allowing it nullable makes more sense and avoid NPE in dhis2 core.