### PR TITLE
feat: Expose ZScoreTableKey parameter

### DIFF
--- a/src/main/java/org/hisp/dhis/rules/functions/ZScoreTableKey.java
+++ b/src/main/java/org/hisp/dhis/rules/functions/ZScoreTableKey.java
@@ -72,4 +72,8 @@ public class ZScoreTableKey
 
         return this.parameter == other.parameter && this.gender == other.gender;
     }
+
+    public float getParameter() {
+        return parameter;
+    }
 }


### PR DESCRIPTION
This PR will expose the parameter variable of the ZScoreTableKey class so that it is easier to retrieve data from the zscore tables and will allow the android app to render graphs based on these tables ([ANDROAPP-3541](https://jira.dhis2.org/browse/ANDROAPP-3541)).