### PR TITLE
fix: [DHIS2-10435] Fix NPE when evaluating variable

### DIFF
--- a/src/main/java/org/hisp/dhis/rules/variables/ProgramRuleConstant.java
+++ b/src/main/java/org/hisp/dhis/rules/variables/ProgramRuleConstant.java
@@ -14,13 +14,14 @@ public class ProgramRuleConstant
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         RuleVariableValue variableValue = visitor.getValueMap().get( ctx.uid0.getText() );
-        String variable = variableValue.value() == null ?
-            variableValue.type().defaultValue() : variableValue.value();
 
-        if ( variable == null )
+        if ( variableValue == null )
         {
             throw new ParserExceptionWithoutContext( "Variable " + ctx.uid0.getText() + " not present" );
         }
+
+        String variable = variableValue.value() == null ?
+            variableValue.type().defaultValue() : variableValue.value();
 
         return variable;
     }

--- a/src/main/java/org/hisp/dhis/rules/variables/ProgramRuleCustomVariable.java
+++ b/src/main/java/org/hisp/dhis/rules/variables/ProgramRuleCustomVariable.java
@@ -15,14 +15,15 @@ public class ProgramRuleCustomVariable
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         RuleVariableValue variableValue = visitor.getValueMap().get( ctx.programRuleVariableName().getText() );
-        String variable = variableValue.value() == null ?
-            variableValue.type().defaultValue() : variableValue.value();
 
-        if ( variable == null )
+        if ( variableValue == null )
         {
             throw new ParserExceptionWithoutContext(
                 "Variable " + ctx.programRuleVariableName().getText() + " not present" );
         }
+
+        String variable = variableValue.value() == null ?
+            variableValue.type().defaultValue() : variableValue.value();
 
         return variable;
     }

--- a/src/main/java/org/hisp/dhis/rules/variables/ProgramRuleVariable.java
+++ b/src/main/java/org/hisp/dhis/rules/variables/ProgramRuleVariable.java
@@ -15,13 +15,14 @@ public class ProgramRuleVariable
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         RuleVariableValue variableValue = visitor.getValueMap().get( ctx.programVariable().getText() );
-        String variable = variableValue.value() == null ?
-            variableValue.type().defaultValue() : variableValue.value();
 
-        if ( variable == null )
+        if ( variableValue == null )
         {
             throw new ParserExceptionWithoutContext( "Variable " + ctx.programVariable().getText() + " not present" );
         }
+
+        String variable = variableValue.value() == null ?
+            variableValue.type().defaultValue() : variableValue.value();
 
         return variable;
     }

--- a/src/main/java/org/hisp/dhis/rules/variables/Variable.java
+++ b/src/main/java/org/hisp/dhis/rules/variables/Variable.java
@@ -15,14 +15,15 @@ public class Variable
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         RuleVariableValue variableValue = visitor.getValueMap().get( RuleExpression.getProgramRuleVariable( ctx ) );
-        String variable = variableValue.value() == null ?
-            variableValue.type().defaultValue() : variableValue.value();
 
-        if ( variable == null )
+        if ( variableValue == null )
         {
             throw new ParserExceptionWithoutContext(
                 "Variable " + RuleExpression.getProgramRuleVariable( ctx ) + " not present" );
         }
+
+        String variable = variableValue.value() == null ?
+            variableValue.type().defaultValue() : variableValue.value();
 
         return variable;
     }

--- a/src/test/java/org/hisp/dhis/rules/RuleEngineTestUtils.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleEngineTestUtils.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.rules;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.common.collect.Lists;
 import org.hisp.dhis.rules.models.Rule;
 import org.hisp.dhis.rules.models.RuleVariable;
 import org.hisp.dhis.rules.models.TriggerEnvironment;
@@ -41,17 +42,28 @@ import java.util.List;
  */
 public class RuleEngineTestUtils
 {
-    public static RuleEngine getRuleEngine(Rule rule, List<RuleVariable> ruleVariables )
+    public static RuleEngine getRuleEngine( Rule rule, List<RuleVariable> ruleVariables )
     {
-        return getRuleEngineBuilder( rule, ruleVariables )
+        return getRuleEngineBuilder( Arrays.asList( rule ), ruleVariables )
+            .build();
+    }
+
+    public static RuleEngine getRuleEngine( List<Rule> rules )
+    {
+        return getRuleEngineBuilder( rules, Lists.<RuleVariable>newArrayList() )
             .build();
     }
 
     public static RuleEngine.Builder getRuleEngineBuilder( Rule rule, List<RuleVariable> ruleVariables )
     {
+        return getRuleEngineBuilder( Arrays.asList( rule ), ruleVariables );
+    }
+
+    private static RuleEngine.Builder getRuleEngineBuilder( List<Rule> rule, List<RuleVariable> ruleVariables )
+    {
         return RuleEngineContext
             .builder()
-            .rules( Arrays.asList( rule ) )
+            .rules( rule )
             .ruleVariables( ruleVariables )
             .supplementaryData( new HashMap<String, List<String>>() )
             .constantsValue( new HashMap<String, String>() )


### PR DESCRIPTION
- Make rules fail individually. If an error is thrown during
  the evaluation of one rule, the others are still evaluated.