### PR TITLE
fix: d2:addDays 2nd arg is numeric DHIS2-12104

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,5 @@ node_modules
 /build
 .build.gradle
 build/
-.gradke/
+.gradle/
 ./src/main/AndroidManifest.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.27</version>
+    <version>2.0.28-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 
@@ -290,7 +290,7 @@
         <dependency>
             <groupId>org.hisp.dhis.parser</groupId>
             <artifactId>dhis-antlr-expression-parser</artifactId>
-            <version>1.0.18</version>
+            <version>1.0.20-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.33-SNAPSHOT</version>
+    <version>2.0.33</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionAddDays.java
+++ b/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionAddDays.java
@@ -35,6 +35,7 @@ import org.joda.time.format.DateTimeFormat;
 
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castDate;
+import static org.hisp.dhis.antlr.AntlrParserUtils.castDouble;
 
 /**
  * @author Zubair Asghar.
@@ -67,7 +68,7 @@ public class RuleFunctionAddDays
     public Object getDescription( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         castDate( visitor.visit( ctx.expr( 0 ) ) );
-        castDate( visitor.visit( ctx.expr( 1 ) ) );
+        castDouble( visitor.visit( ctx.expr( 1 ) ) );
 
         return CommonExpressionVisitor.DEFAULT_DATE_VALUE;
     }


### PR DESCRIPTION
Change 2nd arg of d2:addDays to expect a Double instead of expecting a Date.

Note that it’s only the `getDescription` method that doesn’t work in the backend because this method was expecting the 2nd arg to be a date instead of a double. See [DHIS2-12104](https://jira.dhis2.org/browse/DHIS2-12104). The getDescription method isn't tested in `RuleFunctionAddDaysTest`. Perhaps we should add a test for `getDescription` at some point for all of the functions.