### PR TITLE
feat: Add unsupported rule action class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         def dependencySpec = "${dependency.groupId}:${dependency.artifactId}:${dependency.version}"
         if (dependency.scope == 'test') {
             dependencies.add 'testImplementation', dependencySpec
-        } else if (dependency.artifactId == 'auto-value') {
+        } else if (dependency.artifactId == 'auto-value' || dependency.artifactId == 'javax.annotation-api') {
             dependencies.add 'compileOnly', dependencySpec
             dependencies.add 'annotationProcessor', dependencySpec
         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         def dependencySpec = "${dependency.groupId}:${dependency.artifactId}:${dependency.version}"
         if (dependency.scope == 'test') {
             dependencies.add 'testImplementation', dependencySpec
-        } else if (dependency.artifactId == 'auto-value' || dependency.artifactId == 'javax.annotation-api') {
+        } else if (dependency.artifactId == 'auto-value' || dependency.artifactId == 'javax.annotation-api' && JavaVersion.current() != JavaVersion.VERSION_1_8) {
             dependencies.add 'compileOnly', dependencySpec
             dependencies.add 'annotationProcessor', dependencySpec
         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.27</version>
+    <version>2.0.28-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/src/main/java/org/hisp/dhis/rules/models/RuleActionUnsupported.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleActionUnsupported.java
@@ -1,0 +1,30 @@
+package org.hisp.dhis.rules.models;
+
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nonnull;
+
+@AutoValue
+public abstract class RuleActionUnsupported
+        extends RuleAction
+{
+
+    @Nonnull
+    public static RuleActionUnsupported create( @Nonnull String content, @Nonnull String actionValueType )
+    {
+        return new AutoValue_RuleActionUnsupported( "", content, actionValueType );
+    }
+
+    /**
+     * @return a message to show to user
+     * when an actionType is not supported
+     */
+    @Nonnull
+    public abstract String content();
+
+    /**
+     * @return name of the unsupported action.
+     */
+    @Nonnull
+    public abstract String actionValueType();
+}


### PR DESCRIPTION
Related to this [ jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4307) for android.

When mapping the DHIS2 android sdk rule action classes to the DHIS2 rule engine action classes we use the RuleActionUnsupported to be able to identify actions not supported in the app (create event, send message and schedule message) and actions with wrong configuration (a HideOptionGroup action without the option field set for example). This allows the app to inform the user about possible problems with the configured rules.