### PR TITLE
chore: Bump to rules 2.0.34, parser 1.0.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.33</version>
+    <version>2.0.34</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 
@@ -291,7 +291,7 @@
         <dependency>
             <groupId>org.hisp.dhis.parser</groupId>
             <artifactId>dhis-antlr-expression-parser</artifactId>
-            <version>1.0.24</version>
+            <version>1.0.25</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Synchronize with `dhis-antlr-expression-parser` version 1.0.25.