### PR TITLE
fix: Return errors from rule-engine when an exception is raised [DHIS2-13468]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.39</version>
+    <version>2.0.40-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/src/main/java/org/hisp/dhis/rules/RuleConditionEvaluator.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleConditionEvaluator.java
@@ -18,19 +18,24 @@ public class RuleConditionEvaluator
 {
     private static final Logger log = LoggerFactory.getLogger( RuleConditionEvaluator.class.getName() );
 
+    public List<RuleEffect> getEvaluatedAndErrorRuleEffects( TrackerObjectType targetType, String targetUid, Map<String, RuleVariableValue> valueMap,
+                                            Map<String, List<String>> supplementaryData, List<Rule> rules )
+    {
+        List<RuleEffect> ruleEffects = new ArrayList<>();
+        for (RuleEvaluationResult ruleEvaluationResult : getRuleEvaluationResults( targetType, targetUid, valueMap, supplementaryData, rules)) {
+                ruleEffects.addAll( ruleEvaluationResult.getRuleEffects() );
+        }
+
+        return ruleEffects;
+    }
+
     public List<RuleEffect> getRuleEffects( TrackerObjectType targetType, String targetUid, Map<String, RuleVariableValue> valueMap,
                                             Map<String, List<String>> supplementaryData, List<Rule> rules )
     {
         List<RuleEffect> ruleEffects = new ArrayList<>();
-        List<RuleEvaluationResult> ruleEvaluationResults = getRuleEvaluationResults( targetType, targetUid, valueMap, supplementaryData, rules);
-        for (RuleEvaluationResult ruleEvaluationResult : ruleEvaluationResults) {
+        for (RuleEvaluationResult ruleEvaluationResult : getRuleEvaluationResults( targetType, targetUid, valueMap, supplementaryData, rules)) {
 
-            log.debug( "Rule " + ruleEvaluationResult.getRule().name() + " with id " + ruleEvaluationResult.getRule().uid() +
-                        " executed for " + targetType.getName() +  "(" + targetUid +")" +
-                        " with condition (" + ruleEvaluationResult.getRule().condition() +  ")" +
-                        " was evaluated " + ruleEvaluationResult.isEvaluatedAs() );
-
-            if (ruleEvaluationResult.isEvaluatedAs() ) {
+            if ( !ruleEvaluationResult.isError() ) {
                 ruleEffects.addAll( ruleEvaluationResult.getRuleEffects() );
             }
         }
@@ -51,34 +56,55 @@ public class RuleConditionEvaluator
         {
             log.debug( "Evaluating programrule: " + rule.name() );
 
-            List<RuleEffect> ruleEffects = new ArrayList<>();
+            try {
+                List<RuleEffect> ruleEffects = new ArrayList<>();
 
-            if ( Boolean.valueOf( process( targetType, targetUid, rule, rule.condition(), valueMap, supplementaryData ) ) )
+            if ( Boolean.valueOf( process( rule.condition(), valueMap, supplementaryData ) ) )
             {
                 for ( RuleAction action : rule.actions() )
                 {
 
-                    //Check if action is assigning value to calculated variable
-                    if ( isAssignToCalculatedValue( action ) )
-                    {
-                        RuleActionAssign ruleActionAssign = (RuleActionAssign) action;
-                        updateValueMap(
-                            Utils.unwrapVariableName( ruleActionAssign.content() ),
-                            RuleVariableValue.create( process( targetType, targetUid, rule, ruleActionAssign.data(), valueMap, supplementaryData ),
-                                RuleValueType.TEXT ),
-                            valueMap
-                        );
+                        //Check if action is assigning value to calculated variable
+                        if (isAssignToCalculatedValue(action)) {
+                            RuleActionAssign ruleActionAssign = (RuleActionAssign) action;
+                            updateValueMap(
+                                    Utils.unwrapVariableName(ruleActionAssign.content()),
+                                    RuleVariableValue.create(process( ruleActionAssign.data(), valueMap, supplementaryData),
+                                            RuleValueType.TEXT),
+                                    valueMap
+                            );
+                        } else {
+                            ruleEffects.add(create( rule, action, valueMap, supplementaryData));
+                        }
                     }
-                    else
-                    {
-                        ruleEffects.add( create( targetType, targetUid, rule, action, valueMap, supplementaryData ) );
-                    }
-                }
 
-                ruleEvaluationResults.add( RuleEvaluationResult.evaluatedResult( rule, ruleEffects ) );
-            } else {
-                ruleEvaluationResults.add( RuleEvaluationResult.notEvaluatedResult( rule ) );
+                    ruleEvaluationResults.add(RuleEvaluationResult.evaluatedResult(rule, ruleEffects));
+                } else {
+                    ruleEvaluationResults.add(RuleEvaluationResult.notEvaluatedResult(rule));
+                }
+            } catch ( ParserExceptionWithoutContext e ) {
+                String errorMessage = "Rule " + rule.name() + " with id " + rule.uid() +
+                        " executed for " + targetType.getName() + "(" + targetUid + ")" +
+                        " with condition (" + rule.condition() + ")" +
+                        " raised an error: " + e.getMessage();
+                log.warn( errorMessage );
+                ruleEvaluationResults.add(RuleEvaluationResult.errorRule(rule, errorMessage));
+            } catch ( Exception e ) {
+                String errorMessage = "Rule " + rule.name() + " with id " + rule.uid() +
+                        " executed for " + targetType.getName() + "(" + targetUid + ")" +
+                        " with condition (" + rule.condition() + ")" +
+                        " raised an unexpected exception: " + e.getMessage();
+                log.error( errorMessage );
+                ruleEvaluationResults.add( RuleEvaluationResult.errorRule( rule, errorMessage ) );
             }
+        }
+
+        for (RuleEvaluationResult ruleEvaluationResult : ruleEvaluationResults) {
+
+            log.debug( "Rule " + ruleEvaluationResult.getRule().name() + " with id " + ruleEvaluationResult.getRule().uid() +
+                    " executed for " + targetType.getName() +  "(" + targetUid +")" +
+                    " with condition (" + ruleEvaluationResult.getRule().condition() +  ")" +
+                    " was evaluated " + ruleEvaluationResult.isEvaluatedAs() );
         }
 
         return ruleEvaluationResults;
@@ -118,42 +144,23 @@ public class RuleConditionEvaluator
         return ruleList;
     }
 
-    private String process( TrackerObjectType targetType, String targetUid, Rule rule, String condition,
-                            Map<String, RuleVariableValue> valueMap, Map<String, List<String>> supplementaryData )
+    private String process( String condition, Map<String, RuleVariableValue> valueMap,
+                            Map<String, List<String>> supplementaryData )
     {
         if ( condition.isEmpty() )
         {
             return "";
         }
-        try
-        {
-            CommonExpressionVisitor commonExpressionVisitor = CommonExpressionVisitor.newBuilder()
-                .withFunctionMap( RuleEngineUtils.FUNCTIONS )
-                .withFunctionMethod( FUNCTION_EVALUATE )
-                .withVariablesMap( valueMap )
-                .withSupplementaryData( supplementaryData )
-                .validateCommonProperties();
 
-            Object result = Parser.visit( condition, commonExpressionVisitor, !isOldAndroidVersion( valueMap, supplementaryData ) );
-            return convertInteger( result ).toString();
-        }
-        catch ( ParserExceptionWithoutContext e )
-        {
-            log.warn( "Rule " + rule.name() + " with id " + rule.uid() +
-                    " executed for " + targetType.getName() +  "(" + targetUid +")" +
-                    " with condition (" + condition +  ")" +
-                    " raised an error: " + e.getMessage() );
-            return "";
-        }
-        catch ( Exception e )
-        {
-            e.printStackTrace();
-            log.error( "Rule " + rule.name() + " with id " + rule.uid() +
-                    " executed for " + targetType.getName() +  "(" + targetUid +")" +
-                    " with condition (" + condition +  ")" +
-                    " raised an unexpected exception: " + e.getMessage() );
-            return "";
-        }
+        CommonExpressionVisitor commonExpressionVisitor = CommonExpressionVisitor.newBuilder()
+            .withFunctionMap( RuleEngineUtils.FUNCTIONS )
+            .withFunctionMethod( FUNCTION_EVALUATE )
+            .withVariablesMap( valueMap )
+            .withSupplementaryData( supplementaryData )
+            .validateCommonProperties();
+
+        Object result = Parser.visit( condition, commonExpressionVisitor, !isOldAndroidVersion( valueMap, supplementaryData ) );
+        return convertInteger( result ).toString();
     }
 
     private Object convertInteger( Object result )
@@ -184,7 +191,7 @@ public class RuleConditionEvaluator
     }
 
     @Nonnull
-    private RuleEffect create( TrackerObjectType targetType, String targetUid, @Nonnull Rule rule,
+    private RuleEffect create( @Nonnull Rule rule,
                                 @Nonnull RuleAction ruleAction,
                                 Map<String, RuleVariableValue> valueMap,
                                 Map<String, List<String>> supplementaryData )
@@ -192,7 +199,7 @@ public class RuleConditionEvaluator
         if ( ruleAction instanceof RuleActionAssign )
         {
             RuleActionAssign ruleActionAssign = (RuleActionAssign) ruleAction;
-            String data = process( targetType, targetUid, rule, ruleActionAssign.data(), valueMap, supplementaryData );
+            String data = process( ruleActionAssign.data(), valueMap, supplementaryData );
             updateValueMap( ruleActionAssign.field(), RuleVariableValue.create( data, RuleValueType.TEXT ), valueMap );
             if ( StringUtils.isEmpty( data ) && StringUtils.isEmpty( ruleActionAssign.data() ) )
             {
@@ -204,7 +211,6 @@ public class RuleConditionEvaluator
             }
         }
 
-        return RuleEffect.create( rule.uid(), ruleAction, process( targetType, targetUid, rule, ruleAction.data(),
-                valueMap, supplementaryData ) );
+        return RuleEffect.create( rule.uid(), ruleAction, process( ruleAction.data(), valueMap, supplementaryData ) );
     }
 }

--- a/src/main/java/org/hisp/dhis/rules/RuleEngineMultipleExecution.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleEngineMultipleExecution.java
@@ -48,7 +48,7 @@ class RuleEngineMultipleExecution
         {
             RuleEnrollment enrollment = enrollments.getKey();
             List<RuleEffect> enrollmentRuleEffects = ruleConditionEvaluator
-                .getRuleEffects( TrackerObjectType.ENROLLMENT, enrollment.enrollment(), enrollments.getValue(),
+                .getEvaluatedAndErrorRuleEffects( TrackerObjectType.ENROLLMENT, enrollment.enrollment(), enrollments.getValue(),
                         supplementaryData, RuleEngineFilter.filterRules( rules, enrollment) );
             ruleEffects.add( new RuleEffects( TrackerObjectType.ENROLLMENT, enrollment.enrollment(),
                 enrollmentRuleEffects ) );
@@ -59,7 +59,7 @@ class RuleEngineMultipleExecution
         {
             RuleEvent event = events.getKey();
             ruleEffects.add( new RuleEffects( TrackerObjectType.EVENT, event.event(),
-                ruleConditionEvaluator.getRuleEffects( TrackerObjectType.EVENT, event.event(), events.getValue(),
+                ruleConditionEvaluator.getEvaluatedAndErrorRuleEffects( TrackerObjectType.EVENT, event.event(), events.getValue(),
                         supplementaryData, RuleEngineFilter.filterRules( rules, event) ) ) );
         }
 

--- a/src/main/java/org/hisp/dhis/rules/Utils.java
+++ b/src/main/java/org/hisp/dhis/rules/Utils.java
@@ -44,6 +44,10 @@ public final class Utils
                 dates.add( d );
             }
         }
+        // TODO: This check is needed as long as DHIS2-13468 is not fixed
+        if ( dates.isEmpty() ) {
+            return null;
+        }
         return dateFormat.format( Collections.max( dates ) );
     }
 
@@ -57,6 +61,10 @@ public final class Utils
             {
                 dates.add( d );
             }
+        }
+        // TODO: This check is needed as long as DHIS2-13468 is not fixed
+        if ( dates.isEmpty() ) {
+            return null;
         }
         return dateFormat.format( Collections.max( dates ) );
     }

--- a/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionLastEventDate.java
+++ b/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionLastEventDate.java
@@ -28,6 +28,7 @@ package org.hisp.dhis.rules.functions;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.rules.parser.expression.function.ScalarFunctionToEvaluate;
@@ -55,7 +56,11 @@ public class RuleFunctionLastEventDate
 
         RuleVariableValue variableValue = valueMap.get( visitor.castStringVisit( ctx.expr( 0 ) ) );
 
-        return wrap( variableValue.eventDate() );
+        if (variableValue.eventDate() == null) {
+            throw new ParserExceptionWithoutContext("Only event present is in the future");
+        }
+
+        return variableValue.eventDate();
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/rules/models/RuleActionError.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleActionError.java
@@ -1,0 +1,20 @@
+package org.hisp.dhis.rules.models;
+
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static org.hisp.dhis.rules.models.AttributeType.UNKNOWN;
+
+@AutoValue
+public abstract class RuleActionError
+    extends RuleAction
+{
+
+    @Nonnull
+    public static RuleActionError create( @Nonnull String data )
+    {
+        return new AutoValue_RuleActionError( data );
+    }
+}

--- a/src/main/java/org/hisp/dhis/rules/models/RuleEvaluationResult.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleEvaluationResult.java
@@ -12,18 +12,28 @@ public class RuleEvaluationResult
 
     private boolean evaluatedAs;
 
+    private boolean error;
+
     public static RuleEvaluationResult evaluatedResult(Rule rule, List<RuleEffect> ruleEffects) {
-        return new RuleEvaluationResult( rule, ruleEffects, true );
+        return new RuleEvaluationResult( rule, ruleEffects, true, false );
     }
 
     public static RuleEvaluationResult notEvaluatedResult(Rule rule) {
-        return new RuleEvaluationResult( rule, new ArrayList<RuleEffect>(), false );
+        return new RuleEvaluationResult( rule, new ArrayList<RuleEffect>(), false, false );
     }
 
-    private RuleEvaluationResult( Rule rule, List<RuleEffect> ruleEffects, boolean evaluatedAs) {
+    public static RuleEvaluationResult errorRule( Rule rule, String errorMessage ) {
+        ArrayList<RuleEffect> effects = new ArrayList<>();
+
+        effects.add(RuleEffect.create(rule.uid(), RuleActionError.create(errorMessage), errorMessage));
+        return new RuleEvaluationResult( rule, effects, false, true );
+    }
+
+    private RuleEvaluationResult( Rule rule, List<RuleEffect> ruleEffects, boolean evaluatedAs, boolean error ) {
         this.rule = rule;
         this.ruleEffects = ruleEffects;
         this.evaluatedAs = evaluatedAs;
+        this.error = error;
     }
 
     public Rule getRule() {
@@ -36,5 +46,9 @@ public class RuleEvaluationResult
 
     public boolean isEvaluatedAs() {
         return evaluatedAs;
+    }
+
+    public boolean isError() {
+        return error;
     }
 }

--- a/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
@@ -88,7 +88,7 @@ public class RuleEngineFunctionTest
         assertThat( getRuleEffectsByUid( ruleEffects, "test_not_failing_event" ).getRuleEffects() ).isNotEmpty();
         assertThat( getRuleEffectsByUid( ruleEffects, "test_not_failing_event" ).getRuleEffects().get( 0 ).data() )
             .isEqualTo( "4" );
-        assertThat( getRuleEffectsByUid( ruleEffects, "test_enrollment" ).getRuleEffects() ).isEmpty();
+        assertThat( getRuleEffectsByUid( ruleEffects, "test_enrollment" ).getRuleEffects() ).isNotEmpty();
 
         ;
     }

--- a/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionLastEventDateTest.java
+++ b/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionLastEventDateTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.rules.functions;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.parser.expression.antlr.ExpressionParser;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.RuleVariableValueBuilder;
@@ -86,8 +87,19 @@ public class RuleFunctionLastEventDateTest
         assertLastEventDate( "test_variable", valueMap, "" );
     }
 
+    @Test(expected = ParserExceptionWithoutContext.class)
+    public void raiseExceptionWhenValueMapDoesHaveNullValue()
+    {
+        String variableWithValue = "test_variable_one";
+        Map<String, RuleVariableValue> valueMap = getValueMapWithValue( variableWithValue, null );
+
+        when( visitor.castStringVisit( mockedFirstExpr ) ).thenReturn( variableWithValue );
+        when( visitor.getValueMap() ).thenReturn( valueMap );
+        functionToTest.evaluate( context, visitor );
+    }
+
     @Test
-    public void returnLastestDateWhenValueExist()
+    public void returnLatestDateWhenValueExist()
     {
         String variableWithValue = "test_variable_one";
 
@@ -101,16 +113,21 @@ public class RuleFunctionLastEventDateTest
         return new HashMap<>();
     }
 
-    private Map<String, RuleVariableValue> getValueMapWithValue( String variableNameWithValue )
+    private Map<String, RuleVariableValue> getValueMapWithValue( String variableNameWithValue, String date )
     {
         Map<String, RuleVariableValue> valueMap = new HashMap<>();
         valueMap.put( variableNameWithValue, RuleVariableValueBuilder
-            .create()
-            .withValue( "value" )
-            .withCandidates( Arrays.<String>asList() )
-            .withEventDate( todayDate ).build() );
+                .create()
+                .withValue( "value" )
+                .withCandidates( Arrays.<String>asList() )
+                .withEventDate( date ).build() );
 
         return valueMap;
+    }
+
+    private Map<String, RuleVariableValue> getValueMapWithValue( String variableNameWithValue )
+    {
+        return getValueMapWithValue( variableNameWithValue, todayDate );
     }
 
     private void assertLastEventDate( String value, Map<String, RuleVariableValue> valueMap, String lastEventDate )


### PR DESCRIPTION
This PR has 2 major changes:

- Instead of just logging an exception during rule engine evaluation, a rule effect with action of type `RuleActionError` is returned with the details of the error message in the data field. I add this type of rule effects only for `RuleEngineMultipleExecution` but if this is something that is not going to break Android part and it can be useful, we can make it as default behaviour. Let me know @Balcan 
- `getLastUpdateDateForPrevious` and `getLastUpdateDate` methods are changed in order to not raise an exception if the only date as a last update date is in the future. We still need to have a discussion and decide what to do in this case, for now this fix avoids rule engine to fail when building context.