### PR TITLE
fix: Consider future date in the last date calculation [DHIS2-13468]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.40</version>
+    <version>2.0.41-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/src/main/java/org/hisp/dhis/rules/Utils.java
+++ b/src/main/java/org/hisp/dhis/rules/Utils.java
@@ -39,15 +39,12 @@ public final class Utils
         for ( RuleDataValue date : ruleDataValues )
         {
             Date d = date.eventDate();
-            if ( !d.after( new Date() ) && d.before( ruleEvent.eventDate() ) )
+            if ( d.before( ruleEvent.eventDate() ) )
             {
                 dates.add( d );
             }
         }
-        // TODO: This check is needed as long as DHIS2-13468 is not fixed
-        if ( dates.isEmpty() ) {
-            return null;
-        }
+
         return dateFormat.format( Collections.max( dates ) );
     }
 
@@ -57,15 +54,9 @@ public final class Utils
         for ( RuleDataValue date : ruleDataValues )
         {
             Date d = date.eventDate();
-            if ( !d.after( new Date() ) )
-            {
-                dates.add( d );
-            }
+            dates.add( d );
         }
-        // TODO: This check is needed as long as DHIS2-13468 is not fixed
-        if ( dates.isEmpty() ) {
-            return null;
-        }
+
         return dateFormat.format( Collections.max( dates ) );
     }
 

--- a/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionLastEventDate.java
+++ b/src/main/java/org/hisp/dhis/rules/functions/RuleFunctionLastEventDate.java
@@ -56,10 +56,6 @@ public class RuleFunctionLastEventDate
 
         RuleVariableValue variableValue = valueMap.get( visitor.castStringVisit( ctx.expr( 0 ) ) );
 
-        if (variableValue.eventDate() == null) {
-            throw new ParserExceptionWithoutContext("Only event present is in the future");
-        }
-
         return variableValue.eventDate();
     }
 

--- a/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
@@ -1429,7 +1429,6 @@ public class RuleEngineFunctionTest
     {
         java.util.Calendar cal = java.util.Calendar.getInstance();
 
-        Date today = cal.getTime();
         cal.add( java.util.Calendar.DATE, -1 );
         Date yesterday = cal.getTime();
         cal.add( java.util.Calendar.DATE, -1 );
@@ -1441,9 +1440,6 @@ public class RuleEngineFunctionTest
             "test_action_content", "d2:lastEventDate('test_var_one')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
             "test_var_one", "test_data_element_one", RuleValueType.TEXT );
-
-        RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "test_rule", "" );
 
@@ -1468,6 +1464,6 @@ public class RuleEngineFunctionTest
 
         assertThat( ruleEffects.size() ).isEqualTo( 1 );
         assertThat( ruleEffects.get( 0 ).ruleAction() ).isEqualTo( ruleAction );
-        assertEquals( dateFormat.format( yesterday ), ruleEffects.get( 0 ).data() );
+        assertEquals( dateFormat.format( dayAfterTomorrow ), ruleEffects.get( 0 ).data() );
     }
 }

--- a/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionLastEventDateTest.java
+++ b/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionLastEventDateTest.java
@@ -87,17 +87,6 @@ public class RuleFunctionLastEventDateTest
         assertLastEventDate( "test_variable", valueMap, "" );
     }
 
-    @Test(expected = ParserExceptionWithoutContext.class)
-    public void raiseExceptionWhenValueMapDoesHaveNullValue()
-    {
-        String variableWithValue = "test_variable_one";
-        Map<String, RuleVariableValue> valueMap = getValueMapWithValue( variableWithValue, null );
-
-        when( visitor.castStringVisit( mockedFirstExpr ) ).thenReturn( variableWithValue );
-        when( visitor.getValueMap() ).thenReturn( valueMap );
-        functionToTest.evaluate( context, visitor );
-    }
-
     @Test
     public void returnLatestDateWhenValueExist()
     {

--- a/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionLeftTest.java
+++ b/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionLeftTest.java
@@ -114,7 +114,6 @@ public class RuleFunctionLeftTest
     @Test( expected = ParserExceptionWithoutContext.class )
     public void throw_parser_exception_without_context_if_position_is_a_text()
     {
-        when( visitor.castStringVisit( mockedFirstExpr ) ).thenReturn( "test_variable_one" );
         when( visitor.castStringVisit( mockedSecondExpr ) ).thenReturn( "text" );
         new RuleFunctionLeft().evaluate( context, visitor );
     }
@@ -122,7 +121,6 @@ public class RuleFunctionLeftTest
     @Test( expected = IllegalArgumentException.class )
     public void throw_illegal_argument_when_number_not_an_integer()
     {
-        when( visitor.castStringVisit( mockedFirstExpr ) ).thenReturn( "yyyy-MM-dd" );
         when( visitor.castStringVisit( mockedSecondExpr ) ).thenReturn( "6.8" );
         new RuleFunctionLeft().evaluate( context, visitor );
     }

--- a/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionRightTest.java
+++ b/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionRightTest.java
@@ -110,7 +110,6 @@ public class RuleFunctionRightTest
     @Test( expected = ParserExceptionWithoutContext.class )
     public void throw_parser_exception_without_context_if_position_is_a_text()
     {
-        when( visitor.castStringVisit( mockedFirstExpr ) ).thenReturn( "test_variable_one" );
         when( visitor.castStringVisit( mockedSecondExpr ) ).thenReturn( "text" );
         new RuleFunctionRight().evaluate( context, visitor );
     }
@@ -118,7 +117,6 @@ public class RuleFunctionRightTest
     @Test( expected = IllegalArgumentException.class )
     public void throw_illegal_argument_when_number_not_an_integer()
     {
-        when( visitor.castStringVisit( mockedFirstExpr ) ).thenReturn( "yyyy-MM-dd" );
         when( visitor.castStringVisit( mockedSecondExpr ) ).thenReturn( "6.8" );
         new RuleFunctionRight().evaluate( context, visitor );
     }

--- a/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionSubStringTest.java
+++ b/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionSubStringTest.java
@@ -126,7 +126,6 @@ public class RuleFunctionSubStringTest
 
         when( visitor.castStringVisit( mockedFirstExpr ) ).thenReturn( "test_variable_one" );
         when( visitor.castStringVisit( mockedSecondExpr ) ).thenReturn( "variable" );
-        when( visitor.castStringVisit( mockedThirdExpr ) ).thenReturn( "3" );
 
         subStringFunction.evaluate( context, visitor );
     }

--- a/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionZpvcTest.java
+++ b/src/test/java/org/hisp/dhis/rules/functions/RuleFunctionZpvcTest.java
@@ -80,8 +80,6 @@ public class RuleFunctionZpvcTest
 
         when( context.expr() ).thenReturn( Lists.newArrayList( mockText, mockNull, mockNumber ) );
         when( visitor.castStringVisit( mockText ) ).thenReturn( "sxsx" );
-        when( visitor.castStringVisit( mockNull ) ).thenReturn( null );
-        when( visitor.castStringVisit( mockNumber ) ).thenReturn( "2" );
 
         functionToTest.evaluate( context, visitor );
     }


### PR DESCRIPTION
Future dates and taken into consideration when calculating the last event update date that is used to define events inside `ProgramRuleVariable` of type `DATAELEMENT_NEWEST_EVENT_PROGRAM` or `DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE `