### PR TITLE
Fix rule action evaluation flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.0.42</version>
+    <version>2.0.43-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 


### PR DESCRIPTION
When a program rules has several rule actions linked. If one of the action throws an exception the remaining actions are not evaluated.