### PR TITLE
feat: Add support for OptionSet and useCodeForOptionSet

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
 
   artifact:
     name: Publish - Nexus
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: unit-test
 
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,7 +26,7 @@ jobs:
 
   artifact:
     name: Publish - Nexus
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: unit-test
 
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
                 <version>3.0.0</version>
                 <configuration>
                     <source>8</source>
+                    <failOnError>false</failOnError>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.1.5-SNAPSHOT</version>
+    <version>2.1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/src/main/java/org/hisp/dhis/rules/Option.java
+++ b/src/main/java/org/hisp/dhis/rules/Option.java
@@ -7,9 +7,9 @@ package org.hisp.dhis.rules;
 
 public class Option
 {
-    private String name;
+    private final String name;
 
-    private String code;
+    private final String code;
 
     public Option(String name, String code) {
         this.name = name;
@@ -22,33 +22,5 @@ public class Option
 
     public String getCode() {
         return code;
-    }
-
-    public static Option.Builder builder()
-    {
-        return new Option.Builder();
-    }
-
-    public static class Builder
-    {
-        private String name;
-        private String code;
-
-        public Option.Builder name(String name )
-        {
-            this.name = name;
-            return this;
-        }
-
-        public Option.Builder code(String code )
-        {
-            this.code = code;
-            return this;
-        }
-
-        public Option build()
-        {
-            return new Option(name, code );
-        }
     }
 }

--- a/src/main/java/org/hisp/dhis/rules/Option.java
+++ b/src/main/java/org/hisp/dhis/rules/Option.java
@@ -24,9 +24,9 @@ public class Option
         return code;
     }
 
-    public static DataItem.Builder builder()
+    public static Option.Builder builder()
     {
-        return new DataItem.Builder();
+        return new Option.Builder();
     }
 
     public static class Builder

--- a/src/main/java/org/hisp/dhis/rules/Option.java
+++ b/src/main/java/org/hisp/dhis/rules/Option.java
@@ -1,0 +1,54 @@
+package org.hisp.dhis.rules;
+
+
+/**
+ * @author rajazubair
+ */
+
+public class Option
+{
+    private String name;
+
+    private String code;
+
+    public Option(String name, String code) {
+        this.name = name;
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public static DataItem.Builder builder()
+    {
+        return new DataItem.Builder();
+    }
+
+    public static class Builder
+    {
+        private String name;
+        private String code;
+
+        public Option.Builder name(String name )
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Option.Builder code(String code )
+        {
+            this.code = code;
+            return this;
+        }
+
+        public Option build()
+        {
+            return new Option(name, code );
+        }
+    }
+}

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariable.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariable.java
@@ -27,4 +27,20 @@ public abstract class RuleVariable
         Map<String, List<RuleDataValue>> allEventValues,
         Map<String, RuleAttributeValue> currentEnrollmentValues,
         Map<String, RuleDataValue> currentEventValues );
+
+    public String getOptionName( String value )
+    {
+        // if no option found then existing value in the context will be used
+        String optionName = value;
+
+        for ( Option op : options() )
+        {
+            if (op.getCode().equals( value ) )
+            {
+                optionName = op.getName();
+            }
+        }
+
+        return optionName;
+    }
 }

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariable.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariable.java
@@ -1,5 +1,6 @@
 package org.hisp.dhis.rules.models;
 
+import org.hisp.dhis.rules.Option;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.RuleVariableValueMapBuilder;
 
@@ -20,6 +21,11 @@ public abstract class RuleVariable
      */
     @Nonnull
     public abstract String name();
+
+    public abstract boolean useCodeForOptionSet();
+
+    @Nonnull
+    public abstract List<Option> options();
 
     public abstract Map<String, RuleVariableValue> createValues( RuleVariableValueMapBuilder builder,
         Map<String, List<RuleDataValue>> allEventValues,

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariable.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariable.java
@@ -8,11 +8,7 @@ import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 
-/*
- * ToDo - add support for next properties:
- *   1) Boolean useCode()
- *   2) List<Option> options()
- */
+
 public abstract class RuleVariable
 {
     /**

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariable.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariable.java
@@ -7,6 +7,7 @@ import org.hisp.dhis.rules.RuleVariableValueMapBuilder;
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 
 public abstract class RuleVariable
@@ -31,16 +32,14 @@ public abstract class RuleVariable
     public String getOptionName( String value )
     {
         // if no option found then existing value in the context will be used
-        String optionName = value;
-
-        for ( Option op : options() )
+        if ( options() == null || options().isEmpty() )
         {
-            if (op.getCode().equals( value ) )
-            {
-                optionName = op.getName();
-            }
+            return value;
         }
-
-        return optionName;
+        return options().stream()
+                .filter( op -> Objects.equals( value, op.getCode() ) )
+                .map( Option::getName )
+                .findAny()
+                .orElse( value );
     }
 }

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableAttribute.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableAttribute.java
@@ -11,7 +11,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hisp.dhis.rules.Utils.dateFormat;
 
@@ -52,16 +51,7 @@ public abstract class RuleVariableAttribute
 
             if ( !this.useCodeForOptionSet() )
             {
-                // if no option found then existing value in the context will be used
-                String optionName = value.value();
-
-                for ( Option op : options() )
-                {
-                    if (op.getCode().equals( value.value() ) )
-                    {
-                        optionName = op.getName();
-                    }
-                }
+                String optionName = getOptionName( value.value() );
 
                 variableValue = RuleVariableValue.create( optionName, this.trackedEntityAttributeType(),
                         Arrays.asList( value.value() ), currentDate );

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableAttribute.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableAttribute.java
@@ -49,18 +49,10 @@ public abstract class RuleVariableAttribute
             RuleAttributeValue value = currentEnrollmentValues
                 .get( this.trackedEntityAttribute() );
 
-            if ( !this.useCodeForOptionSet() )
-            {
-                String optionName = getOptionName( value.value() );
+            String optionValue = this.useCodeForOptionSet() ? value.value() : getOptionName( value.value() );
 
-                variableValue = RuleVariableValue.create( optionName, this.trackedEntityAttributeType(),
-                        Arrays.asList( value.value() ), currentDate );
-            }
-            else
-            {
-                variableValue = RuleVariableValue.create( value.value(), this.trackedEntityAttributeType(),
-                        Arrays.asList( value.value() ), currentDate );
-            }
+            variableValue = RuleVariableValue.create( optionValue, this.trackedEntityAttributeType(),
+                    List.of(optionValue), currentDate );
         }
         else
         {

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableCalculatedValue.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableCalculatedValue.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.rules.models;
  */
 
 import com.google.auto.value.AutoValue;
+import org.hisp.dhis.rules.Option;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.RuleVariableValueMapBuilder;
 
@@ -46,10 +47,10 @@ public abstract class RuleVariableCalculatedValue
     extends RuleVariable
 {
     @Nonnull
-    public static RuleVariableCalculatedValue create( @Nonnull String name,
-        @Nonnull String variable, @Nonnull RuleValueType variableType )
+    public static RuleVariableCalculatedValue create(@Nonnull String name,
+                                                     @Nonnull String variable, @Nonnull RuleValueType variableType, boolean useCodeForOptionSet, List<Option> options)
     {
-        return new AutoValue_RuleVariableCalculatedValue( name, variable, variableType );
+        return new AutoValue_RuleVariableCalculatedValue( name, useCodeForOptionSet, options, variable, variableType );
     }
 
     @Nonnull

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableCurrentEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableCurrentEvent.java
@@ -41,7 +41,7 @@ public abstract class RuleVariableCurrentEvent
 
             if ( !this.useCodeForOptionSet() )
             {
-               String optionName = getOptionName( options(), value );
+               String optionName = getOptionName( value.value() );
 
                variableValue = RuleVariableValue.create( optionName, this.dataElementType(),
                         Arrays.asList( value.value() ), getLastUpdateDate( Arrays.asList( value ) ) );

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableCurrentEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableCurrentEvent.java
@@ -39,18 +39,10 @@ public abstract class RuleVariableCurrentEvent
         {
             RuleDataValue value = currentEventValues.get( this.dataElement() );
 
-            if ( !this.useCodeForOptionSet() )
-            {
-               String optionName = getOptionName( value.value() );
+            String optionValue = this.useCodeForOptionSet() ? value.value() : getOptionName( value.value() );
 
-               variableValue = RuleVariableValue.create( optionName, this.dataElementType(),
-                        Arrays.asList( value.value() ), getLastUpdateDate( Arrays.asList( value ) ) );
-            }
-            else
-            {
-                variableValue = RuleVariableValue.create( value.value(), this.dataElementType(),
-                        Arrays.asList( value.value() ), getLastUpdateDate( Arrays.asList( value ) ) );
-            }
+            variableValue = RuleVariableValue.create( optionValue, this.dataElementType(),
+                List.of( optionValue ), getLastUpdateDate( List.of( value ) ) );
         }
         else
         {

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableCurrentEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableCurrentEvent.java
@@ -1,6 +1,7 @@
 package org.hisp.dhis.rules.models;
 
 import com.google.auto.value.AutoValue;
+import org.hisp.dhis.rules.Option;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.RuleVariableValueMapBuilder;
 
@@ -18,10 +19,10 @@ public abstract class RuleVariableCurrentEvent
 {
 
     @Nonnull
-    public static RuleVariableCurrentEvent create( @Nonnull String name,
-        @Nonnull String dataElement, @Nonnull RuleValueType dataElementValueType )
+    public static RuleVariableCurrentEvent create(@Nonnull String name,
+                                                  @Nonnull String dataElement, @Nonnull RuleValueType dataElementValueType, boolean useCodeForOptionSet, List<Option> options)
     {
-        return new AutoValue_RuleVariableCurrentEvent( name, dataElement, dataElementValueType );
+        return new AutoValue_RuleVariableCurrentEvent( name, useCodeForOptionSet, options, dataElement, dataElementValueType );
     }
 
     @Override
@@ -37,8 +38,19 @@ public abstract class RuleVariableCurrentEvent
         if ( currentEventValues.containsKey( this.dataElement() ) )
         {
             RuleDataValue value = currentEventValues.get( this.dataElement() );
-            variableValue = RuleVariableValue.create( value.value(), this.dataElementType(),
-                Arrays.asList( value.value() ), getLastUpdateDate( Arrays.asList( value ) ) );
+
+            if ( !this.useCodeForOptionSet() )
+            {
+               String optionName = getOptionName( options(), value );
+
+               variableValue = RuleVariableValue.create( optionName, this.dataElementType(),
+                        Arrays.asList( value.value() ), getLastUpdateDate( Arrays.asList( value ) ) );
+            }
+            else
+            {
+                variableValue = RuleVariableValue.create( value.value(), this.dataElementType(),
+                        Arrays.asList( value.value() ), getLastUpdateDate( Arrays.asList( value ) ) );
+            }
         }
         else
         {

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableDataElement.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableDataElement.java
@@ -1,6 +1,9 @@
 package org.hisp.dhis.rules.models;
 
+import org.hisp.dhis.rules.Option;
+
 import javax.annotation.Nonnull;
+import java.util.List;
 
 abstract class RuleVariableDataElement
     extends RuleVariable
@@ -12,4 +15,19 @@ abstract class RuleVariableDataElement
     @Nonnull
     public abstract RuleValueType dataElementType();
 
+    public String getOptionName(List<Option> options, RuleDataValue value )
+    {
+        // if no option found then existing value in the context will be used
+        String optionName = value.value();
+
+        for ( Option op : options() )
+        {
+            if (op.getCode().equals( value.value() ) )
+            {
+                optionName = op.getName();
+            }
+        }
+
+        return optionName;
+    }
 }

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableDataElement.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableDataElement.java
@@ -1,9 +1,7 @@
 package org.hisp.dhis.rules.models;
 
-import org.hisp.dhis.rules.Option;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 
 abstract class RuleVariableDataElement
     extends RuleVariable
@@ -14,20 +12,4 @@ abstract class RuleVariableDataElement
 
     @Nonnull
     public abstract RuleValueType dataElementType();
-
-    public String getOptionName(List<Option> options, RuleDataValue value )
-    {
-        // if no option found then existing value in the context will be used
-        String optionName = value.value();
-
-        for ( Option op : options() )
-        {
-            if (op.getCode().equals( value.value() ) )
-            {
-                optionName = op.getName();
-            }
-        }
-
-        return optionName;
-    }
 }

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestEvent.java
@@ -44,18 +44,11 @@ public abstract class RuleVariableNewestEvent
 
             RuleDataValue value = ruleDataValues.get( 0 );
 
-            if ( !this.useCodeForOptionSet() )
-            {
-                String optionName = getOptionName( value.value() );
+            String optionValue = this.useCodeForOptionSet() ? value.value() : getOptionName( value.value() );
 
-                variableValue = RuleVariableValue.create( optionName,
-                        this.dataElementType(), Utils.values( ruleDataValues ), getLastUpdateDate( ruleDataValues ) );
-            }
-            else
-            {
-                variableValue = RuleVariableValue.create( value.value(),
-                        this.dataElementType(), Utils.values( ruleDataValues ), getLastUpdateDate( ruleDataValues ) );
-            }
+            variableValue = RuleVariableValue.create( optionValue,
+                this.dataElementType(), Utils.values( ruleDataValues ), getLastUpdateDate( ruleDataValues ) );
+
 
             valueMap.put( this.name(), variableValue );
         }

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestEvent.java
@@ -7,7 +7,6 @@ import org.hisp.dhis.rules.RuleVariableValueMapBuilder;
 import org.hisp.dhis.rules.Utils;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +46,7 @@ public abstract class RuleVariableNewestEvent
 
             if ( !this.useCodeForOptionSet() )
             {
-                String optionName = getOptionName( options(), value );
+                String optionName = getOptionName( value.value() );
 
                 variableValue = RuleVariableValue.create( optionName,
                         this.dataElementType(), Utils.values( ruleDataValues ), getLastUpdateDate( ruleDataValues ) );

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestEvent.java
@@ -1,11 +1,13 @@
 package org.hisp.dhis.rules.models;
 
 import com.google.auto.value.AutoValue;
+import org.hisp.dhis.rules.Option;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.RuleVariableValueMapBuilder;
 import org.hisp.dhis.rules.Utils;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,10 +20,10 @@ public abstract class RuleVariableNewestEvent
 {
 
     @Nonnull
-    public static RuleVariableNewestEvent create( @Nonnull String name,
-        @Nonnull String dataElement, @Nonnull RuleValueType dataElementValueType )
+    public static RuleVariableNewestEvent create(@Nonnull String name,
+                                                 @Nonnull String dataElement, @Nonnull RuleValueType dataElementValueType, boolean useCodeForOptionSet, List<Option> options)
     {
-        return new AutoValue_RuleVariableNewestEvent( name, dataElement, dataElementValueType );
+        return new AutoValue_RuleVariableNewestEvent( name, useCodeForOptionSet, options, dataElement, dataElementValueType );
     }
 
     @Override
@@ -39,9 +41,26 @@ public abstract class RuleVariableNewestEvent
         }
         else
         {
-            valueMap.put( this.name(), RuleVariableValue.create( ruleDataValues.get( 0 ).value(),
-                this.dataElementType(), Utils.values( ruleDataValues ), getLastUpdateDate( ruleDataValues ) ) );
+            RuleVariableValue variableValue;
+
+            RuleDataValue value = ruleDataValues.get( 0 );
+
+            if ( !this.useCodeForOptionSet() )
+            {
+                String optionName = getOptionName( options(), value );
+
+                variableValue = RuleVariableValue.create( optionName,
+                        this.dataElementType(), Utils.values( ruleDataValues ), getLastUpdateDate( ruleDataValues ) );
+            }
+            else
+            {
+                variableValue = RuleVariableValue.create( value.value(),
+                        this.dataElementType(), Utils.values( ruleDataValues ), getLastUpdateDate( ruleDataValues ) );
+            }
+
+            valueMap.put( this.name(), variableValue );
         }
+
         return valueMap;
     }
 }

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestStageEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestStageEvent.java
@@ -1,6 +1,7 @@
 package org.hisp.dhis.rules.models;
 
 import com.google.auto.value.AutoValue;
+import org.hisp.dhis.rules.Option;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.RuleVariableValueMapBuilder;
 import org.hisp.dhis.rules.Utils;
@@ -19,10 +20,10 @@ public abstract class RuleVariableNewestStageEvent
 {
 
     @Nonnull
-    public static RuleVariableNewestStageEvent create( @Nonnull String name, @Nonnull String dataElement,
-        @Nonnull String programStage, @Nonnull RuleValueType dataElementType )
+    public static RuleVariableNewestStageEvent create(@Nonnull String name, @Nonnull String dataElement,
+                                                      @Nonnull String programStage, @Nonnull RuleValueType dataElementType, boolean useCodeForOptionSet, List<Option> options)
     {
-        return new AutoValue_RuleVariableNewestStageEvent( name, dataElement,
+        return new AutoValue_RuleVariableNewestStageEvent( name, useCodeForOptionSet, options, dataElement,
             dataElementType, programStage );
     }
 
@@ -58,9 +59,26 @@ public abstract class RuleVariableNewestStageEvent
         }
         else
         {
-            valueMap.put( this.name(), RuleVariableValue.create( stageRuleDataValues.get( 0 ).value(),
-                this.dataElementType(), Utils.values( stageRuleDataValues ),
-                getLastUpdateDate( stageRuleDataValues ) ) );
+            RuleVariableValue variableValue;
+
+            RuleDataValue value = stageRuleDataValues.get( 0 );
+
+            if ( !this.useCodeForOptionSet() )
+            {
+                String optionName = getOptionName( options(), value );
+
+                variableValue = RuleVariableValue.create( optionName,
+                        this.dataElementType(), Utils.values( stageRuleDataValues ),
+                        getLastUpdateDate( stageRuleDataValues ) );
+            }
+            else
+            {
+                variableValue = RuleVariableValue.create( value.value(),
+                        this.dataElementType(), Utils.values( stageRuleDataValues ),
+                        getLastUpdateDate( stageRuleDataValues ) );
+            }
+
+            valueMap.put( this.name(), variableValue );
         }
 
         return valueMap;

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestStageEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestStageEvent.java
@@ -65,7 +65,7 @@ public abstract class RuleVariableNewestStageEvent
 
             if ( !this.useCodeForOptionSet() )
             {
-                String optionName = getOptionName( options(), value );
+                String optionName = getOptionName( value.value() );
 
                 variableValue = RuleVariableValue.create( optionName,
                         this.dataElementType(), Utils.values( stageRuleDataValues ),

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestStageEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariableNewestStageEvent.java
@@ -63,20 +63,11 @@ public abstract class RuleVariableNewestStageEvent
 
             RuleDataValue value = stageRuleDataValues.get( 0 );
 
-            if ( !this.useCodeForOptionSet() )
-            {
-                String optionName = getOptionName( value.value() );
+            String optionValue = this.useCodeForOptionSet() ? value.value() : getOptionName( value.value() );
 
-                variableValue = RuleVariableValue.create( optionName,
+            variableValue = RuleVariableValue.create( optionValue,
                         this.dataElementType(), Utils.values( stageRuleDataValues ),
                         getLastUpdateDate( stageRuleDataValues ) );
-            }
-            else
-            {
-                variableValue = RuleVariableValue.create( value.value(),
-                        this.dataElementType(), Utils.values( stageRuleDataValues ),
-                        getLastUpdateDate( stageRuleDataValues ) );
-            }
 
             valueMap.put( this.name(), variableValue );
         }

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariablePreviousEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariablePreviousEvent.java
@@ -45,7 +45,7 @@ public abstract class RuleVariablePreviousEvent
                 {
                     if ( !this.useCodeForOptionSet() )
                     {
-                        String optionName = getOptionName( options(), ruleDataValue );
+                        String optionName = getOptionName( ruleDataValue.value() );
 
                         variableValue = RuleVariableValue.create( optionName, this.dataElementType(),
                                 Utils.values( ruleDataValues ),

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariablePreviousEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariablePreviousEvent.java
@@ -20,7 +20,7 @@ public abstract class RuleVariablePreviousEvent
 
     @Nonnull
     public static RuleVariablePreviousEvent create(@Nonnull String name,
-                                                   @Nonnull String dataElement, @Nonnull RuleValueType valueType, boolean useCodeForOptionSet, List<Option> options)
+       @Nonnull String dataElement, @Nonnull RuleValueType valueType, boolean useCodeForOptionSet, List<Option> options)
     {
         return new AutoValue_RuleVariablePreviousEvent( name, useCodeForOptionSet, options , dataElement, valueType );
     }
@@ -48,7 +48,7 @@ public abstract class RuleVariablePreviousEvent
                     variableValue = RuleVariableValue.create( optionValue, this.dataElementType(),
                         Utils.values( ruleDataValues ),
                         getLastUpdateDateForPrevious( ruleDataValues, builder.ruleEvent ) );
-
+                    break;
                 }
             }
         }

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariablePreviousEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariablePreviousEvent.java
@@ -1,6 +1,7 @@
 package org.hisp.dhis.rules.models;
 
 import com.google.auto.value.AutoValue;
+import org.hisp.dhis.rules.Option;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.RuleVariableValueMapBuilder;
 import org.hisp.dhis.rules.Utils;
@@ -18,10 +19,10 @@ public abstract class RuleVariablePreviousEvent
 {
 
     @Nonnull
-    public static RuleVariablePreviousEvent create( @Nonnull String name,
-        @Nonnull String dataElement, @Nonnull RuleValueType valueType )
+    public static RuleVariablePreviousEvent create(@Nonnull String name,
+                                                   @Nonnull String dataElement, @Nonnull RuleValueType valueType, boolean useCodeForOptionSet, List<Option> options)
     {
-        return new AutoValue_RuleVariablePreviousEvent( name, dataElement, valueType );
+        return new AutoValue_RuleVariablePreviousEvent( name, useCodeForOptionSet, options , dataElement, valueType );
     }
 
     @Override
@@ -42,10 +43,22 @@ public abstract class RuleVariablePreviousEvent
                 // which is assumed to be best candidate.
                 if ( builder.ruleEvent.eventDate().compareTo( ruleDataValue.eventDate() ) > 0 )
                 {
-                    variableValue = RuleVariableValue.create( ruleDataValue.value(), this.dataElementType(),
-                        Utils.values( ruleDataValues ),
-                        getLastUpdateDateForPrevious( ruleDataValues, builder.ruleEvent ) );
-                    break;
+                    if ( !this.useCodeForOptionSet() )
+                    {
+                        String optionName = getOptionName( options(), ruleDataValue );
+
+                        variableValue = RuleVariableValue.create( optionName, this.dataElementType(),
+                                Utils.values( ruleDataValues ),
+                                getLastUpdateDateForPrevious( ruleDataValues, builder.ruleEvent ) );
+                        break;
+                    }
+                    else
+                    {
+                        variableValue = RuleVariableValue.create( ruleDataValue.value(), this.dataElementType(),
+                                Utils.values( ruleDataValues ),
+                                getLastUpdateDateForPrevious( ruleDataValues, builder.ruleEvent ) );
+                        break;
+                    }
                 }
             }
         }

--- a/src/main/java/org/hisp/dhis/rules/models/RuleVariablePreviousEvent.java
+++ b/src/main/java/org/hisp/dhis/rules/models/RuleVariablePreviousEvent.java
@@ -43,22 +43,12 @@ public abstract class RuleVariablePreviousEvent
                 // which is assumed to be best candidate.
                 if ( builder.ruleEvent.eventDate().compareTo( ruleDataValue.eventDate() ) > 0 )
                 {
-                    if ( !this.useCodeForOptionSet() )
-                    {
-                        String optionName = getOptionName( ruleDataValue.value() );
+                    String optionValue = this.useCodeForOptionSet() ? ruleDataValue.value() : getOptionName( ruleDataValue.value() );
 
-                        variableValue = RuleVariableValue.create( optionName, this.dataElementType(),
-                                Utils.values( ruleDataValues ),
-                                getLastUpdateDateForPrevious( ruleDataValues, builder.ruleEvent ) );
-                        break;
-                    }
-                    else
-                    {
-                        variableValue = RuleVariableValue.create( ruleDataValue.value(), this.dataElementType(),
-                                Utils.values( ruleDataValues ),
-                                getLastUpdateDateForPrevious( ruleDataValues, builder.ruleEvent ) );
-                        break;
-                    }
+                    variableValue = RuleVariableValue.create( optionValue, this.dataElementType(),
+                        Utils.values( ruleDataValues ),
+                        getLastUpdateDateForPrevious( ruleDataValues, builder.ruleEvent ) );
+
                 }
             }
         }

--- a/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
@@ -38,8 +38,10 @@ import static org.junit.Assert.assertTrue;
 public class RuleEngineFunctionTest
 {
     private static final String DATE_PATTERN = "yyyy-MM-dd";
+    private static final boolean USE_CODE_FOR_OPTION_SET = true;
+    private static final boolean USE_NAME_FOR_OPTION_SET = !USE_CODE_FOR_OPTION_SET;
 
-    private SimpleDateFormat dateFormat = new SimpleDateFormat( DATE_PATTERN, Locale.US );
+    private final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat( DATE_PATTERN, Locale.US );
 
     @Test
     public void evaluateFailingRule()
@@ -136,6 +138,60 @@ public class RuleEngineFunctionTest
 
         assertThat( ruleEffects.size() ).isEqualTo( 1 );
         assertThat( ruleEffects.get( 0 ).data() ).isEqualTo( "true" );
+        assertThat( ruleEffects.get( 0 ).ruleAction() ).isEqualTo( ruleAction );
+    }
+
+    @Test
+    public void optionSetNameShouldBeUsed()
+            throws Exception
+    {
+        Option option1 = Option.builder().name("name1").code("code1").build();
+        Option option2 = Option.builder().name("name2").code("code2").build();
+
+        List<Option> options = Arrays.asList( option1, option2 );
+
+        RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
+                "test_action_content", "#{test_variable}" );
+        RuleVariable ruleVariable = RuleVariableCurrentEvent.create(
+                "test_variable", "test_data_element", RuleValueType.TEXT, USE_NAME_FOR_OPTION_SET, options);
+        Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
+
+        RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
+
+        RuleEvent ruleEvent = RuleEvent.create( "test_event", "test_program_stage",
+                RuleEvent.Status.ACTIVE, new Date(), new Date(), "", null, Arrays.asList( RuleDataValue.create(
+                        new Date(), "test_program_stage", "test_data_element", option1.getCode() ) ), "", null);
+        List<RuleEffect> ruleEffects = ruleEngine.evaluate( ruleEvent ).call();
+
+        assertThat( ruleEffects ).hasSize( 1 );
+        assertThat( ruleEffects.get( 0 ).data() ).isEqualTo( option1.getName() );
+        assertThat( ruleEffects.get( 0 ).ruleAction() ).isEqualTo( ruleAction );
+    }
+
+    @Test
+    public void optionSetCodeShouldBeUsed()
+            throws Exception
+    {
+        Option option1 = Option.builder().name("name1").code("code1").build();
+        Option option2 = Option.builder().name("name2").code("code2").build();
+
+        List<Option> options = Arrays.asList( option1, option2 );
+
+        RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
+                "test_action_content", "#{test_variable}" );
+        RuleVariable ruleVariable = RuleVariableCurrentEvent.create(
+                "test_variable", "test_data_element", RuleValueType.TEXT, USE_CODE_FOR_OPTION_SET, options);
+        Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
+
+        RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
+
+        RuleEvent ruleEvent = RuleEvent.create( "test_event", "test_program_stage",
+                RuleEvent.Status.ACTIVE, new Date(), new Date(), "", null, Arrays.asList( RuleDataValue.create(
+                        new Date(), "test_program_stage", "test_data_element", option2.getCode() ) ), "", null);
+        List<RuleEffect> ruleEffects = ruleEngine.evaluate( ruleEvent ).call();
+
+        assertThat( ruleEffects ).hasSize( 1 );
+        assertThat( ruleEffects.get( 0 ).data() ).isEqualTo( option2.getCode() );
         assertThat( ruleEffects.get( 0 ).ruleAction() ).isEqualTo( ruleAction );
     }
 
@@ -1476,6 +1532,6 @@ public class RuleEngineFunctionTest
 
         assertThat( ruleEffects.size() ).isEqualTo( 1 );
         assertThat( ruleEffects.get( 0 ).ruleAction() ).isEqualTo( ruleAction );
-        assertEquals( dateFormat.format( dayAfterTomorrow ), ruleEffects.get( 0 ).data() );
+        assertEquals( DATE_FORMAT.format( dayAfterTomorrow ), ruleEffects.get( 0 ).data() );
     }
 }

--- a/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
@@ -145,14 +145,14 @@ public class RuleEngineFunctionTest
     public void optionSetNameShouldBeUsed()
             throws Exception
     {
-        Option option1 = Option.builder().name("name1").code("code1").build();
-        Option option2 = Option.builder().name("name2").code("code2").build();
+        Option option1 = new Option("name1", "code1");
+        Option option2 = new Option("name2", "code2");
 
         List<Option> options = Arrays.asList( option1, option2 );
 
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
                 "test_action_content", "#{test_variable}" );
-        RuleVariable ruleVariable = RuleVariableCurrentEvent.create(
+        RuleVariable ruleVariable = RuleVariableNewestEvent.create(
                 "test_variable", "test_data_element", RuleValueType.TEXT, USE_NAME_FOR_OPTION_SET, options);
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -172,8 +172,8 @@ public class RuleEngineFunctionTest
     public void optionSetCodeShouldBeUsed()
             throws Exception
     {
-        Option option1 = Option.builder().name("name1").code("code1").build();
-        Option option2 = Option.builder().name("name2").code("code2").build();
+        Option option1 = new Option("name1", "code1");
+        Option option2 = new Option("name2", "code2");
 
         List<Option> options = Arrays.asList( option1, option2 );
 

--- a/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleEngineFunctionTest.java
@@ -4,7 +4,6 @@ import org.hisp.dhis.rules.models.Rule;
 import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionDisplayKeyValuePair;
 import org.hisp.dhis.rules.models.RuleActionDisplayText;
-import org.hisp.dhis.rules.models.RuleAttributeValue;
 import org.hisp.dhis.rules.models.RuleDataValue;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.rules.models.RuleEffects;
@@ -125,7 +124,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:hasValue(#{test_variable})" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent.create(
-            "test_variable", "test_data_element", RuleValueType.TEXT );
+            "test_variable", "test_data_element", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
@@ -148,7 +147,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:hasValue('test_variable')" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent.create(
-            "test_variable", "test_data_element", RuleValueType.TEXT );
+            "test_variable", "test_data_element", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
@@ -170,7 +169,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:hasValue(#{test_variable})" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent.create(
-            "test_variable", "test_data_element", RuleValueType.TEXT );
+            "test_variable", "test_data_element", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
@@ -192,7 +191,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "V{program_stage_name}" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent
-            .create( "variable", "test_data_element", RuleValueType.TEXT );
+            .create( "variable", "test_data_element", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
@@ -214,9 +213,9 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:daysBetween(#{test_var_one}, #{test_var_two})" );
         RuleVariable ruleVariableOne = RuleVariableCurrentEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableCurrentEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariableOne, ruleVariableTwo ) );
@@ -240,9 +239,9 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:daysBetween(#{test_var_one}, '2018-01-01')" );
         RuleVariable ruleVariableOne = RuleVariableCurrentEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableCurrentEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariableOne, ruleVariableTwo ) );
@@ -271,7 +270,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:inOrgUnitGroup(#{test_var_one})" );
         RuleVariable ruleVariableOne = RuleVariableCurrentEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -309,7 +308,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:inOrgUnitGroup('OU_GROUP_ID')" );
         RuleVariable ruleVariableOne = RuleVariableCurrentEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -346,7 +345,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:hasUserRole(#{test_var_one})" );
         RuleVariable ruleVariableOne = RuleVariableCurrentEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -383,7 +382,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:hasUserRole('role1')" );
         RuleVariable ruleVariableOne = RuleVariableCurrentEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -414,9 +413,9 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:addDays(#{test_var_one}, #{test_var_two})" );
         RuleVariable ruleVariableOne = RuleVariableCurrentEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableCurrentEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariableOne, ruleVariableTwo ) );
@@ -450,7 +449,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:countIfValue(#{test_var_one}, 'condition')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -483,7 +482,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:countIfValue('test_var_one', 'condition')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -515,10 +514,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:count(#{test_var_one})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -553,7 +552,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
                 "test_action_content", "d2:count(#{test_var_one})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-                "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+                "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "d2:hasValue(V{current_date}) && d2:count(#{test_var_one}) > 0",
             Arrays.asList( ruleAction ), "", "" );
@@ -582,7 +581,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
                 "test_action_content", "d2:count(#{test_var_one})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-                "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+                "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "d2:hasValue(V{current_date}) || d2:count(#{test_var_one}) > 0",
             Arrays.asList( ruleAction ), "", "" );
@@ -613,10 +612,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:count('test_var_one')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -652,7 +651,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction1 = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:round(#{test_var_one})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction1 ), "", "" );
 
@@ -676,7 +675,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:modulus(#{test_var_one}, 2)" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -700,7 +699,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:substring(#{test_var_one}, 1, 3)" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -724,9 +723,9 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:weeksBetween(#{test_var_one}, #{test_var_two})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine.Builder ruleEngineBuilder = getRuleEngineBuilder( rule,
@@ -751,9 +750,9 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:monthsBetween(#{test_var_one}, #{test_var_two})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine.Builder ruleEngineBuilder = getRuleEngineBuilder( rule,
@@ -778,9 +777,9 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:yearsBetween(#{test_var_one}, #{test_var_two})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule
             .create( null, null, "d2:yearsBetween('2016-01-01', '2018-09-01') == 2", Arrays.asList( ruleAction ), "",
                 "" );
@@ -807,11 +806,11 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:zpvc( '1', '0', '-1' )" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.NUMERIC );
+            "test_var_two", "test_data_element_two", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariableThree = RuleVariableNewestEvent.create(
-            "test_var_three", "test_data_element_two", RuleValueType.NUMERIC );
+            "test_var_three", "test_data_element_two", RuleValueType.NUMERIC, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine.Builder ruleEngineBuilder = getRuleEngineBuilder( rule,
@@ -876,7 +875,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:countIfZeroPos(#{test_var_one})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -910,7 +909,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:countIfZeroPos('test_var_one')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -943,7 +942,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:left(#{test_var_one}, 4)" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -967,7 +966,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:right(#{test_var_one}, 2)" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -991,7 +990,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:concatenate(#{test_var_one}, '+days')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -1015,7 +1014,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:validatePattern(#{test_var_one}, '.*555.*')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -1050,7 +1049,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:length(#{test_var_one})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -1074,7 +1073,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:split(#{test_var_one},'-',2)" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -1102,11 +1101,11 @@ public class RuleEngineFunctionTest
                 "/ 5 * d2:ceil(#{test_var_two})" );
 
         RuleVariable ruleVariableOne = RuleVariableCurrentEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableCurrentEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.NUMERIC );
+            "test_var_two", "test_data_element_two", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariableThree = RuleVariableCurrentEvent.create(
-            "test_var_three", "test_data_element_three", RuleValueType.NUMERIC );
+            "test_var_three", "test_data_element_three", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -1132,10 +1131,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "true" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule
             .create( null, null, "d2:zScoreWFA(1,#{test_var_one},#{test_var_two}) == 0", Arrays.asList( ruleAction ),
@@ -1162,10 +1161,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "true" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule
             .create( null, null, "d2:zScoreHFA(12,#{test_var_one},#{test_var_two}) == -3", Arrays.asList( ruleAction ),
@@ -1192,10 +1191,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "true" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule
             .create( null, null, "d2:zScoreHFA(10,#{test_var_one},#{test_var_two}) == -2", Arrays.asList( ruleAction ),
@@ -1222,10 +1221,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "true" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule
             .create( null, null, "d2:zScoreWFH(52,#{test_var_one},A{test_var_two}) < 2", Arrays.asList( ruleAction ),
@@ -1252,10 +1251,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:zScoreWFH(81.5,9.6,'female') == 2" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule
             .create( null, null, "d2:zScoreWFH(81.5,#{test_var_one},#{test_var_two}) == 2", Arrays.asList( ruleAction ),
@@ -1282,10 +1281,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "true" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule
             .create( null, null, "d2:maxValue(#{test_var_one}) == 8.0", Arrays.asList( ruleAction ), "", "" );
@@ -1323,10 +1322,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "true" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule
             .create( null, null, "d2:maxValue('test_var_one') == 8.0", Arrays.asList( ruleAction ), "", "" );
@@ -1363,10 +1362,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:minValue(#{test_var_one})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -1403,10 +1402,10 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:minValue('test_var_one')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC );
+            "test_var_one", "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -1452,7 +1451,7 @@ public class RuleEngineFunctionTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:lastEventDate('test_var_one')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_var_one", "test_data_element_one", RuleValueType.TEXT );
+            "test_var_one", "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "test_rule", "" );
 

--- a/src/test/java/org/hisp/dhis/rules/RuleEngineValueTypesTest.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleEngineValueTypesTest.java
@@ -33,7 +33,7 @@ public class RuleEngineValueTypesTest
             .createForFeedback( "test_action_content", "#{test_variable}" );
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent
-            .create( "test_variable", "test_data_element", RuleValueType.BOOLEAN );
+            .create( "test_variable", "test_data_element", RuleValueType.BOOLEAN, true, new ArrayList<>());
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
 
@@ -54,7 +54,7 @@ public class RuleEngineValueTypesTest
             .createForFeedback( "test_action_content", "#{test_variable}" );
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent
-            .create( "test_variable", "test_data_element", RuleValueType.NUMERIC );
+            .create( "test_variable", "test_data_element", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
 
@@ -75,7 +75,7 @@ public class RuleEngineValueTypesTest
             .createForFeedback( "test_action_content", "#{test_variable}" );
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent
-            .create( "test_variable", "test_data_element", RuleValueType.TEXT );
+            .create( "test_variable", "test_data_element", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
 

--- a/src/test/java/org/hisp/dhis/rules/RuleEngineVariableNameTest.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleEngineVariableNameTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -67,19 +68,19 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction10 = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:round(A{" + VARIABLE_NAME + "})" );
         RuleVariable ruleVariable1 = RuleVariableNewestEvent.create(
-            UID01, "test_data_element1", RuleValueType.NUMERIC );
+            UID01, "test_data_element1", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariable2 = RuleVariableNewestEvent.create(
-            VARIABLE_NAME, "test_data_element2", RuleValueType.NUMERIC );
+            VARIABLE_NAME, "test_data_element2", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariable3 = RuleVariableNewestEvent.create(
-            UID0, "test_data_element3", RuleValueType.NUMERIC );
+            UID0, "test_data_element3", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariable4 = RuleVariableNewestEvent.create(
-            UID0WILD, "test_data_element4", RuleValueType.NUMERIC );
+            UID0WILD, "test_data_element4", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariable5 = RuleVariableNewestEvent.create(
-            UID01WILD, "test_data_element5", RuleValueType.NUMERIC );
+            UID01WILD, "test_data_element5", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariable6 = RuleVariableNewestEvent.create(
-            UID012, "test_data_element6", RuleValueType.NUMERIC );
+            UID012, "test_data_element6", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariable7 = RuleVariableNewestEvent.create(
-            UID0WILD2, "test_data_element7", RuleValueType.NUMERIC );
+            UID0WILD2, "test_data_element7", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         List<RuleAction> actions = Arrays
             .asList( ruleAction1, ruleAction2, ruleAction3, ruleAction4, ruleAction5, ruleAction6, ruleAction7,
@@ -139,7 +140,7 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:hasValue(#{" + UID01 + "})" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent.create(
-            UID01, "test_data_element", RuleValueType.TEXT );
+            UID01, "test_data_element", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
@@ -161,7 +162,7 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:hasValue(#{" + VARIABLE_NAME + "})" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent.create(
-            VARIABLE_NAME, "test_data_element", RuleValueType.TEXT );
+            VARIABLE_NAME, "test_data_element", RuleValueType.TEXT, true, new ArrayList<>());
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable ) );
@@ -183,7 +184,7 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:countIfValue(#{" + VARIABLE_NAME + "}, 'condition')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            VARIABLE_NAME, "test_data_element_one", RuleValueType.TEXT );
+            VARIABLE_NAME, "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -215,7 +216,7 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:countIfValue(#{" + UID01 + "}, 'condition')" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            UID01, "test_data_element_one", RuleValueType.TEXT );
+            UID01, "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -247,10 +248,10 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:count(#{" + VARIABLE_NAME + "})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            VARIABLE_NAME, "test_data_element_one", RuleValueType.TEXT );
+            VARIABLE_NAME, "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -286,10 +287,10 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:count(#{" + UID01 + "})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            UID01, "test_data_element_one", RuleValueType.TEXT );
+            UID01, "test_data_element_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -325,7 +326,7 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:countIfZeroPos(#{" + VARIABLE_NAME + "})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            VARIABLE_NAME, "test_data_element_one", RuleValueType.NUMERIC );
+            VARIABLE_NAME, "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -358,7 +359,7 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayText.createForFeedback(
             "test_action_content", "d2:countIfZeroPos(#{" + UID01 + "})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            UID01, "test_data_element_one", RuleValueType.NUMERIC );
+            UID01, "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -391,10 +392,10 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "true" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            VARIABLE_NAME, "test_data_element_one", RuleValueType.NUMERIC );
+            VARIABLE_NAME, "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule
             .create( null, null, "d2:maxValue(#{" + VARIABLE_NAME + "}) == 8.0", Arrays.asList( ruleAction ), "", "" );
@@ -431,10 +432,10 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "true" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            UID01, "test_data_element_one", RuleValueType.NUMERIC );
+            UID01, "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule
             .create( null, null, "d2:maxValue(#{" + UID01 + "}) == 8.0", Arrays.asList( ruleAction ), "", "" );
@@ -471,10 +472,10 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:minValue(#{" + VARIABLE_NAME + "})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            VARIABLE_NAME, "test_data_element_one", RuleValueType.NUMERIC );
+            VARIABLE_NAME, "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 
@@ -511,10 +512,10 @@ public class RuleEngineVariableNameTest
         RuleAction ruleAction = RuleActionDisplayKeyValuePair.createForFeedback(
             "test_action_content", "d2:minValue(#{" + UID01 + "})" );
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            UID01, "test_data_element_one", RuleValueType.NUMERIC );
+            UID01, "test_data_element_one", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_var_two", "test_data_element_two", RuleValueType.TEXT );
+            "test_var_two", "test_data_element_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Rule rule = Rule.create( null, null, "true", Arrays.asList( ruleAction ), "", "" );
 

--- a/src/test/java/org/hisp/dhis/rules/RuleVariableValueMapBuilderTest.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleVariableValueMapBuilderTest.java
@@ -13,7 +13,6 @@ import org.hisp.dhis.rules.models.RuleVariableNewestStageEvent;
 import org.hisp.dhis.rules.models.RuleVariablePreviousEvent;
 import org.hisp.dhis.rules.models.TriggerEnvironment;
 import org.hisp.dhis.rules.util.MockRuleEnrollment;
-import org.hisp.dhis.rules.util.MockRuleEvent;
 import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +31,6 @@ import java.util.Map;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.hisp.dhis.rules.RuleVariableValueAssert.assertThatVariable;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith( JUnit4.class )
 public class RuleVariableValueMapBuilderTest
@@ -67,9 +65,9 @@ public class RuleVariableValueMapBuilderTest
         throws ParseException
     {
         RuleVariable ruleVariableOne = RuleVariableCurrentEvent.create(
-            "test_variable_one", "test_dataelement_one", RuleValueType.TEXT );
+            "test_variable_one", "test_dataelement_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableCurrentEvent.create(
-            "test_variable_two", "test_dataelement_two", RuleValueType.TEXT );
+            "test_variable_two", "test_dataelement_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Date eventDate = dateFormat.parse( "2015-01-01" );
         Date dueDate = dateFormat.parse( "2016-01-01" );
@@ -134,9 +132,9 @@ public class RuleVariableValueMapBuilderTest
         throws ParseException
     {
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_variable_one", "test_dataelement_one", RuleValueType.TEXT );
+            "test_variable_one", "test_dataelement_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_variable_two", "test_dataelement_two", RuleValueType.TEXT );
+            "test_variable_two", "test_dataelement_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Date oldestEventDate = dateFormat.parse( "2013-01-01" );
         Date newestEventDate = dateFormat.parse( "2017-01-01" );
@@ -198,9 +196,9 @@ public class RuleVariableValueMapBuilderTest
         throws ParseException
     {
         RuleVariable ruleVariableOne = RuleVariableNewestEvent.create(
-            "test_variable_one", "test_dataelement_one", RuleValueType.TEXT );
+            "test_variable_one", "test_dataelement_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableNewestEvent.create(
-            "test_variable_two", "test_dataelement_two", RuleValueType.TEXT );
+            "test_variable_two", "test_dataelement_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Date dateEventOne = dateFormat.parse( "2013-01-01" );
         Date dateEventTwo = dateFormat.parse( "2014-01-01" );
@@ -267,7 +265,7 @@ public class RuleVariableValueMapBuilderTest
         throws ParseException
     {
         RuleVariable ruleVariable = RuleVariableNewestStageEvent.create( "test_variable",
-            "test_dataelement", "test_program_stage_one", RuleValueType.TEXT );
+            "test_dataelement", "test_program_stage_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Date dateEventOne = dateFormat.parse( "2014-02-03" );
         Date dateEventTwo = dateFormat.parse( "2014-03-03" );
@@ -326,7 +324,7 @@ public class RuleVariableValueMapBuilderTest
         throws ParseException
     {
         RuleVariable ruleVariable = RuleVariableNewestStageEvent.create( "test_variable",
-            "test_dataelement", "test_program_stage_one", RuleValueType.TEXT );
+            "test_dataelement", "test_program_stage_one", RuleValueType.TEXT, true, new ArrayList<>());
 
         Date dateEventOne = dateFormat.parse( "2014-03-03" );
         Date dateEventTwo = dateFormat.parse( "2015-02-03" );
@@ -372,7 +370,7 @@ public class RuleVariableValueMapBuilderTest
         throws ParseException
     {
         RuleVariable ruleVariable = RuleVariablePreviousEvent.create( "test_variable",
-            "test_dataelement", RuleValueType.TEXT );
+            "test_dataelement", RuleValueType.TEXT, true, new ArrayList<>());
 
         Date dateEventOne = dateFormat.parse( "2014-02-03" );
         Date dateEventTwo = dateFormat.parse( "2014-03-03" );
@@ -431,9 +429,9 @@ public class RuleVariableValueMapBuilderTest
         throws ParseException
     {
         RuleVariable ruleVariableOne = RuleVariableAttribute.create( "test_variable_one",
-            "test_attribute_one", RuleValueType.TEXT );
+            "test_attribute_one", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableAttribute.create( "test_variable_two",
-            "test_attribute_two", RuleValueType.TEXT );
+            "test_attribute_two", RuleValueType.TEXT, true, new ArrayList<>());
 
         Date eventDate = dateFormat.parse( "2015-01-01" );
         Date enrollmentDate = dateFormat.parse( "2014-03-01" );
@@ -515,11 +513,11 @@ public class RuleVariableValueMapBuilderTest
         throws ParseException
     {
         RuleVariable ruleVariableOne = RuleVariableAttribute.create( "test_variable_one",
-            "test_attribute_one", RuleValueType.NUMERIC );
+            "test_attribute_one", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableAttribute.create( "test_variable_two",
-            "test_attribute_two", RuleValueType.TEXT );
+            "test_attribute_two", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableThree = RuleVariableCurrentEvent.create( "test_variable_three",
-            "test_dataelement_one", RuleValueType.BOOLEAN );
+            "test_dataelement_one", RuleValueType.BOOLEAN, true, new ArrayList<>());
 
         String currentDate = dateFormat.format( new Date() );
         Date enrollmentDate = dateFormat.parse( "2017-02-02" );
@@ -578,11 +576,11 @@ public class RuleVariableValueMapBuilderTest
         throws ParseException
     {
         RuleVariable ruleVariableOne = RuleVariableAttribute.create( "test_variable_one",
-            "test_attribute_one", RuleValueType.NUMERIC );
+            "test_attribute_one", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariableTwo = RuleVariableAttribute.create( "test_variable_two",
-            "test_attribute_two", RuleValueType.TEXT );
+            "test_attribute_two", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariableThree = RuleVariableCurrentEvent.create( "test_variable_three",
-            "test_dataelement_one", RuleValueType.BOOLEAN );
+            "test_dataelement_one", RuleValueType.BOOLEAN, true, new ArrayList<>());
 
         String currentDate = dateFormat.format( new Date() );
         Date enrollmentDate = dateFormat.parse( "2017-02-02" );

--- a/src/test/java/org/hisp/dhis/rules/VariableValueTypeTest.java
+++ b/src/test/java/org/hisp/dhis/rules/VariableValueTypeTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -60,9 +61,9 @@ public class VariableValueTypeTest
                 .createForFeedback( "test_action_content", "#{test_variable}" );
         Rule rule = Rule.create( null, null, "#{test_variable} > #{test_variable2}", Arrays.asList( ruleAction ), "", "" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent
-                .create( "test_variable", "test_data_element", RuleValueType.NUMERIC );
+                .create( "test_variable", "test_data_element", RuleValueType.NUMERIC, true, new ArrayList<>());
         RuleVariable ruleVariable2 = RuleVariableCurrentEvent
-                .create( "test_variable2", "test_data_element2", RuleValueType.NUMERIC );
+                .create( "test_variable2", "test_data_element2", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable, ruleVariable2 ) );
 
@@ -85,9 +86,9 @@ public class VariableValueTypeTest
                 .createForFeedback( "test_action_content", "#{test_variable}" );
         Rule rule = Rule.create( null, null, "#{test_variable} > #{test_variable2}", Arrays.asList( ruleAction ), "", "" );
         RuleVariable ruleVariable = RuleVariableCurrentEvent
-                .create( "test_variable", "test_data_element", RuleValueType.TEXT );
+                .create( "test_variable", "test_data_element", RuleValueType.TEXT, true, new ArrayList<>());
         RuleVariable ruleVariable2 = RuleVariableCurrentEvent
-                .create( "test_variable2", "test_data_element2", RuleValueType.TEXT );
+                .create( "test_variable2", "test_data_element2", RuleValueType.TEXT, true, new ArrayList<>());
 
         RuleEngine ruleEngine = getRuleEngine( rule, Arrays.asList( ruleVariable, ruleVariable2 ) );
 

--- a/src/test/java/org/hisp/dhis/rules/models/CalculatedValueTest.java
+++ b/src/test/java/org/hisp/dhis/rules/models/CalculatedValueTest.java
@@ -200,7 +200,7 @@ public class CalculatedValueTest
     private RuleEngine.Builder getRuleEngine( List<org.hisp.dhis.rules.models.Rule> rules )
     {
         RuleVariable ruleVariable = RuleVariableCalculatedValue
-            .create( "test_calculated_value", "", RuleValueType.TEXT );
+            .create( "test_calculated_value", "", RuleValueType.TEXT, true, new ArrayList<>());
 
         return RuleEngineContext
             .builder()

--- a/src/test/java/org/hisp/dhis/rules/models/RuleVariableAttributeTest.java
+++ b/src/test/java/org/hisp/dhis/rules/models/RuleVariableAttributeTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @RunWith( JUnit4.class )
@@ -13,26 +15,26 @@ public class RuleVariableAttributeTest
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullName()
     {
-        RuleVariableAttribute.create( null, "test_attribute", RuleValueType.TEXT );
+        RuleVariableAttribute.create( null, "test_attribute", RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullTrackedEntityAttribute()
     {
-        RuleVariableAttribute.create( "test_variable", null, RuleValueType.TEXT );
+        RuleVariableAttribute.create( "test_variable", null, RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullTrackedEntityAttributeType()
     {
-        RuleVariableAttribute.create( "test_variable", "test_attribute", null );
+        RuleVariableAttribute.create( "test_variable", "test_attribute", null, true, new ArrayList<>());
     }
 
     @Test
     public void createShouldPropagatePropertiesCorrectly()
     {
         RuleVariableAttribute ruleVariableAttribute = RuleVariableAttribute.create(
-            "test_variable", "test_attribute", RuleValueType.NUMERIC );
+            "test_variable", "test_attribute", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         assertThat( ruleVariableAttribute.name() ).isEqualTo( "test_variable" );
         assertThat( ruleVariableAttribute.trackedEntityAttribute() ).isEqualTo( "test_attribute" );

--- a/src/test/java/org/hisp/dhis/rules/models/RuleVariableCurrentEventTest.java
+++ b/src/test/java/org/hisp/dhis/rules/models/RuleVariableCurrentEventTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @RunWith( JUnit4.class )
@@ -13,26 +15,26 @@ public class RuleVariableCurrentEventTest
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullName()
     {
-        RuleVariableCurrentEvent.create( null, "test_dataelement", RuleValueType.TEXT );
+        RuleVariableCurrentEvent.create( null, "test_dataelement", RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullDataElement()
     {
-        RuleVariableCurrentEvent.create( "test_variable", null, RuleValueType.TEXT );
+        RuleVariableCurrentEvent.create( "test_variable", null, RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullDataElementType()
     {
-        RuleVariableCurrentEvent.create( "test_variable", "test_dataelement", null );
+        RuleVariableCurrentEvent.create( "test_variable", "test_dataelement", null, true, new ArrayList<>());
     }
 
     @Test
     public void createShouldPropagatePropertiesCorrectly()
     {
         RuleVariableCurrentEvent ruleVariableCurrentEvent = RuleVariableCurrentEvent.create(
-            "test_variable", "test_dataelement", RuleValueType.NUMERIC );
+            "test_variable", "test_dataelement", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         assertThat( ruleVariableCurrentEvent.name() ).isEqualTo( "test_variable" );
         assertThat( ruleVariableCurrentEvent.dataElement() ).isEqualTo( "test_dataelement" );

--- a/src/test/java/org/hisp/dhis/rules/models/RuleVariableNewestEventTest.java
+++ b/src/test/java/org/hisp/dhis/rules/models/RuleVariableNewestEventTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @RunWith( JUnit4.class )
@@ -13,26 +15,26 @@ public class RuleVariableNewestEventTest
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullName()
     {
-        RuleVariableNewestEvent.create( null, "test_dataelement", RuleValueType.TEXT );
+        RuleVariableNewestEvent.create( null, "test_dataelement", RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullDataElement()
     {
-        RuleVariableNewestEvent.create( "test_variable", null, RuleValueType.TEXT );
+        RuleVariableNewestEvent.create( "test_variable", null, RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullDataElementType()
     {
-        RuleVariableNewestEvent.create( "test_variable", "test_dataelement", null );
+        RuleVariableNewestEvent.create( "test_variable", "test_dataelement", null, true, new ArrayList<>());
     }
 
     @Test
     public void createShouldPropagatePropertiesCorrectly()
     {
         RuleVariableNewestEvent ruleVariableNewestEvent = RuleVariableNewestEvent.create(
-            "test_variable", "test_dataelement", RuleValueType.NUMERIC );
+            "test_variable", "test_dataelement", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         assertThat( ruleVariableNewestEvent.name() ).isEqualTo( "test_variable" );
         assertThat( ruleVariableNewestEvent.dataElement() ).isEqualTo( "test_dataelement" );

--- a/src/test/java/org/hisp/dhis/rules/models/RuleVariableNewestStageEventTest.java
+++ b/src/test/java/org/hisp/dhis/rules/models/RuleVariableNewestStageEventTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @RunWith( JUnit4.class )
@@ -14,35 +16,35 @@ public class RuleVariableNewestStageEventTest
     public void createShouldThrowOnNullName()
     {
         RuleVariableNewestStageEvent
-            .create( null, "test_dataelement", "test_programstage", RuleValueType.TEXT );
+            .create( null, "test_dataelement", "test_programstage", RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullDataElement()
     {
         RuleVariableNewestStageEvent
-            .create( "test_variable", null, "test_programstage", RuleValueType.TEXT );
+            .create( "test_variable", null, "test_programstage", RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullProgramStage()
     {
         RuleVariableNewestStageEvent
-            .create( "test_variable", "test_dataelement", null, RuleValueType.TEXT );
+            .create( "test_variable", "test_dataelement", null, RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullDataElementType()
     {
         RuleVariableNewestStageEvent
-            .create( "test_variable", "test_dataelement", "test_programstage", null );
+            .create( "test_variable", "test_dataelement", "test_programstage", null, true, new ArrayList<>());
     }
 
     @Test
     public void createShouldPropagatePropertiesCorrectly()
     {
         RuleVariableNewestStageEvent ruleVariablePreviousEvent = RuleVariableNewestStageEvent.create(
-            "test_variable", "test_dataelement", "test_programstage", RuleValueType.NUMERIC );
+            "test_variable", "test_dataelement", "test_programstage", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         assertThat( ruleVariablePreviousEvent.name() ).isEqualTo( "test_variable" );
         assertThat( ruleVariablePreviousEvent.dataElement() ).isEqualTo( "test_dataelement" );

--- a/src/test/java/org/hisp/dhis/rules/models/RuleVariablePreviousEventTest.java
+++ b/src/test/java/org/hisp/dhis/rules/models/RuleVariablePreviousEventTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @RunWith( JUnit4.class )
@@ -13,26 +15,26 @@ public class RuleVariablePreviousEventTest
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullName()
     {
-        RuleVariablePreviousEvent.create( null, "test_dataelement", RuleValueType.TEXT );
+        RuleVariablePreviousEvent.create( null, "test_dataelement", RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullDataElement()
     {
-        RuleVariablePreviousEvent.create( "test_variable", null, RuleValueType.TEXT );
+        RuleVariablePreviousEvent.create( "test_variable", null, RuleValueType.TEXT, true, new ArrayList<>());
     }
 
     @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullDataElementType()
     {
-        RuleVariablePreviousEvent.create( "test_variable", "test_dataelement", null );
+        RuleVariablePreviousEvent.create( "test_variable", "test_dataelement", null, true, new ArrayList<>());
     }
 
     @Test
     public void createShouldPropagatePropertiesCorrectly()
     {
         RuleVariablePreviousEvent ruleVariablePreviousEvent = RuleVariablePreviousEvent.create(
-            "test_variable", "test_dataelement", RuleValueType.NUMERIC );
+            "test_variable", "test_dataelement", RuleValueType.NUMERIC, true, new ArrayList<>());
 
         assertThat( ruleVariablePreviousEvent.name() ).isEqualTo( "test_variable" );
         assertThat( ruleVariablePreviousEvent.dataElement() ).isEqualTo( "test_dataelement" );

--- a/src/test/java/org/hisp/dhis/rules/util/MockRuleVariable.java
+++ b/src/test/java/org/hisp/dhis/rules/util/MockRuleVariable.java
@@ -1,5 +1,6 @@
 package org.hisp.dhis.rules.util;
 
+import org.hisp.dhis.rules.Option;
 import org.hisp.dhis.rules.RuleVariableValue;
 import org.hisp.dhis.rules.RuleVariableValueMapBuilder;
 import org.hisp.dhis.rules.models.RuleAttributeValue;
@@ -14,6 +15,18 @@ public class MockRuleVariable extends RuleVariable {
     @Nonnull
     @Override
     public String name() {
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public boolean useCodeForOptionSet() {
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public List<Option> options() {
         return null;
     }
 


### PR DESCRIPTION
[DHIS2-13541](https://dhis2.atlassian.net/browse/DHIS2-13541)
PR will add support for use of `Option.name `or `Option.code` based on the flag `useCodeForOptionSet`.

-  Add useCodeForOptionSet flag in RuleVariable
-  Add List<Option> in RuleVariable
-  Add List<Option> in RuleVariable. While building rule-engine context, this List will be populated with dhis2-core OptionSet.Options


[DHIS2-13541]: https://dhis2.atlassian.net/browse/DHIS2-13541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ