### PR TITLE
fix: Do not remove single quotes from values in rule variables [DHIS2-13275]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/src/main/java/org/hisp/dhis/rules/RuleVariableValue.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleVariableValue.java
@@ -22,57 +22,22 @@ public abstract class RuleVariableValue implements VariableValue
     @Nonnull
     public static RuleVariableValue create( @Nonnull RuleValueType ruleValueType )
     {
-        return new AutoValue_RuleVariableValue( null, ruleValueType,
-            Collections.unmodifiableList( new ArrayList<String>() ), getFormattedDate( new Date() ) );
+        return new AutoValue_RuleVariableValue( null, ruleValueType, List.of(), getFormattedDate( new Date() ) );
     }
 
     @Nonnull
     public static RuleVariableValue create( @Nonnull String value,
         @Nonnull RuleValueType ruleValueType )
     {
-        if ( ruleValueType == null )
-        {
-            throw new IllegalArgumentException( "Invalid value type" );
-        }
-        // clean-up the value before processing it
-        String processedValue = value == null ? null : value.replace( "'", "" );
-
-        // if text processedValue, wrap it
-        if ( RuleValueType.TEXT.equals( ruleValueType ) )
-        {
-            processedValue = String.format( Locale.US, "%s", processedValue );
-        }
-
-        /*if (RuleValueType.NUMERIC.equals(ruleValueType)) {TODO: UNCOMMENT WHEN VALUE FORMAT IN CLIENT IS READY
-            processedValue = getFormattedNumber(value);
-        }*/
-
-        return new AutoValue_RuleVariableValue( processedValue, ruleValueType,
-            Collections.unmodifiableList( new ArrayList<String>() ), getFormattedDate( new Date() ) );
+        return new AutoValue_RuleVariableValue( value, ruleValueType,
+            List.of(), getFormattedDate( new Date() ) );
     }
 
     @Nonnull
     public static RuleVariableValue create( @Nonnull String value,
         @Nonnull RuleValueType ruleValueType, @Nonnull List<String> candidates, @Nonnull String eventDate )
     {
-        if ( candidates == null )
-        {
-            throw new IllegalArgumentException( "Candidate cannot be null" );
-        }
-        // clean-up the value before processing it
-        String processedValue = value.replace( "'", "" );
-
-        // if text processedValue, wrap it
-        if ( RuleValueType.TEXT.equals( ruleValueType ) )
-        {
-            processedValue = String.format( Locale.US, "%s", processedValue );
-        }
-
-       /* if (RuleValueType.NUMERIC.equals(ruleValueType)) {TODO: UNCOMMENT WHEN VALUE FORMAT IN CLIENT IS READY
-            processedValue = getFormattedNumber(value);
-        }*/
-
-        return new AutoValue_RuleVariableValue( processedValue, ruleValueType,
+        return new AutoValue_RuleVariableValue( value, ruleValueType,
             Collections.unmodifiableList( candidates ), eventDate );
     }
 
@@ -82,13 +47,6 @@ public abstract class RuleVariableValue implements VariableValue
         format.applyPattern( DATE_PATTERN );
 
         return format.format( date );
-    }
-
-    private static String getFormattedNumber( String number )
-    {
-        DecimalFormatSymbols otherSymbols = new DecimalFormatSymbols( Locale.US );
-        otherSymbols.setDecimalSeparator( '.' );
-        return new DecimalFormat( NUMBER_PATTERN, otherSymbols ).format( Float.valueOf( number ) );
     }
 
     @Nullable

--- a/src/test/java/org/hisp/dhis/rules/RuleVariableValueTest.java
+++ b/src/test/java/org/hisp/dhis/rules/RuleVariableValueTest.java
@@ -73,13 +73,13 @@ public class RuleVariableValueTest
         assertThat( variableValue.candidates().get( 1 ) ).isEqualTo( "false" );
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullValueType()
     {
         RuleVariableValue.create( "test_value", null );
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = NullPointerException.class )
     public void createShouldThrowOnNullCandidateList()
     {
         RuleVariableValue.create( "test_value", RuleValueType.TEXT, null, dateFormat.format( new Date() ) );


### PR DESCRIPTION
Values of rule variables were `processed` removing single quotes.
This was creating an issue when a data element or an attributes had a value with a single quote in it.
Is it safe to just remove that code that was removing single quotes from values? @zubaira 