### PR TITLE
fix: Assign null value when parser return empty string [DHIS2-15261]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.hisp.dhis.rules</groupId>
     <artifactId>rule-engine</artifactId>
-    <version>2.1.7-SNAPSHOT</version>
+    <version>2.1.8-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rule-engine</name>
 

--- a/src/main/java/org/hisp/dhis/rules/RuleConditionEvaluator.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleConditionEvaluator.java
@@ -224,9 +224,9 @@ public class RuleConditionEvaluator
             RuleActionAssign ruleActionAssign = (RuleActionAssign) ruleAction;
             String data = process( ruleActionAssign.data(), valueMap, supplementaryData, Expression.Mode.RULE_ENGINE_ACTION);
             updateValueMap( ruleActionAssign.field(), RuleVariableValue.create( data, RuleValueType.TEXT ), valueMap );
-            if ( StringUtils.isEmpty( data ) && StringUtils.isEmpty( ruleActionAssign.data() ) )
+            if ( StringUtils.isEmpty( data ) )
             {
-                return RuleEffect.create( rule.uid(), ruleAction, ruleActionAssign.data() );
+                return RuleEffect.create( rule.uid(), ruleAction, null );
             }
             else
             {


### PR DESCRIPTION
When expression-parser evaluates `data` of an assign action to empty string, we convert it to null