### PR TITLE
fix: RuleVariableType was verified using the wrong type

### DIFF
--- a/src/jsMain/kotlin/org/hisp/dhis/rules/RuleVariableJs.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/rules/RuleVariableJs.kt
@@ -16,7 +16,7 @@ data class RuleVariableJs(
 ){
     init {
         require(RULE_VALUE_TYPES.contains(fieldType)) { "RuleValueType type must be one of: $RULE_VALUE_TYPES" }
-        require(TYPES.contains(fieldType)) { "RuleVariableType type must be one of: $TYPES" }
+        require(TYPES.contains(type)) { "RuleVariableType type must be one of: $TYPES" }
     }
 
     companion object {


### PR DESCRIPTION
The validation of RuleVariableType property was done using the wrong enum.

This bug only affects the JS component.