### PR TITLE
fix: use JsMap wrapper (JS component)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,11 @@ kotlin {
         }
         val jvmMain by getting
         val jvmTest by getting
-        val jsMain by getting
+        val jsMain by getting {
+            dependencies {
+                api("org.jetbrains.kotlin-wrappers:kotlin-js:1.0.0-pre.722")
+            }
+        }
         val jsTest by getting
         val nativeMain by getting
         val nativeTest by getting

--- a/src/jsMain/kotlin/org/hisp/dhis/rules/RuleActionJs.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/rules/RuleActionJs.kt
@@ -1,11 +1,11 @@
 package org.hisp.dhis.rules
 
-import org.hisp.dhis.lib.expression.js.Entry
+import js.collections.JsMap
 
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 data class RuleActionJs(
     val data: String?,
     val type: String,
-    val values: Array<Entry<String, String>> = emptyArray()
+    val values: JsMap<String, String> = JsMap()
 )

--- a/src/jsMain/kotlin/org/hisp/dhis/rules/RuleEngineContextJs.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/rules/RuleEngineContextJs.kt
@@ -1,12 +1,12 @@
 package org.hisp.dhis.rules
 
-import org.hisp.dhis.lib.expression.js.Entry
+import js.collections.JsMap
 
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 data class RuleEngineContextJs(
     val rules: Array<RuleJs>,
     val ruleVariables: Array<RuleVariableJs>,
-    val supplementaryData: Array<Entry<String, Array<String>>> = emptyArray(),
-    val constantsValues: Array<Entry<String, String>> = emptyArray()
+    val supplementaryData: JsMap<String, Array<String>> = JsMap(),
+    val constantsValues: JsMap<String, String> = JsMap()
 )

--- a/src/jsMain/kotlin/org/hisp/dhis/rules/RuleEngineJs.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/rules/RuleEngineJs.kt
@@ -1,8 +1,9 @@
 package org.hisp.dhis.rules
 
+import js.array.tupleOf
+import js.collections.JsMap
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
-import org.hisp.dhis.lib.expression.js.Entry
 import org.hisp.dhis.rules.api.DataItem
 import org.hisp.dhis.rules.api.ItemValueType
 import org.hisp.dhis.rules.api.RuleEngine
@@ -12,10 +13,10 @@ import org.hisp.dhis.rules.models.*
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 class RuleEngineJs {
-    fun validate(expression: String, dataItemStore: Array<Entry<String, DataItemJs>>): RuleValidationResult{
+    fun validate(expression: String, dataItemStore: JsMap<String, DataItemJs>): RuleValidationResult{
         return RuleEngine.getInstance().validate(expression, toMap(dataItemStore, {it}, ::toDataItemJava))
     }
-    fun validateDataFieldExpression(expression: String, dataItemStore: Array<Entry<String, DataItemJs>>): RuleValidationResult{
+    fun validateDataFieldExpression(expression: String, dataItemStore: JsMap<String, DataItemJs>): RuleValidationResult{
         return RuleEngine.getInstance().validateDataFieldExpression(expression, toMap(dataItemStore, {it}, ::toDataItemJava))
     }
     fun evaluateAll(enrollmentTarget: RuleEnrollmentJs?, eventsTarget: Array<RuleEventJs>, executionContext: RuleEngineContextJs): Array<RuleEffectsJs>{
@@ -38,9 +39,9 @@ class RuleEngineJs {
             .map(::toRuleEffectJs).toTypedArray()
     }
 
-    private fun <Kf, Vf, K, V> toMap(map: Array<Entry<Kf, Vf>>, key: (Kf) -> K, value: (Vf) -> V): Map<K, V> {
+    private fun <Kf, Vf, K, V> toMap(map: JsMap<Kf, Vf>, key: (Kf) -> K, value: (Vf) -> V): Map<K, V> {
         val res : MutableMap<K, V> = mutableMapOf()
-        map.forEach { e -> res[key(e.key)] = value(e.value) }
+        map.forEach { v, k -> res[key(k)] = value(v) }
         return res
     }
 
@@ -122,7 +123,7 @@ class RuleEngineJs {
         return RuleActionJs(
             data = ruleAction.data,
             type = ruleAction.type,
-            values = ruleAction.values.entries.map { e -> Entry(e.key, e.value) }.toTypedArray()
+            values = JsMap(ruleAction.values.entries.map { e -> tupleOf(e.key, e.value) }.toTypedArray())
         )
     }
 


### PR DESCRIPTION
Uses Kotlin js wrappers to expose native JS Map instead of `Array<Entry>`.