### PR TITLE
Update readme and keys

### DIFF
--- a/.github/workflows/job-publish.yml
+++ b/.github/workflows/job-publish.yml
@@ -32,6 +32,8 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
+          SIGNING_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}
 
       - name: Publish NPMJS
         run: ./.github/workflows/scripts/publish-npm.sh

--- a/README.md
+++ b/README.md
@@ -60,7 +60,28 @@ List of supported environment (contextual) variables:
  - enrollment_id
  - enrollment_count
  - incident_date
- - tei_count  
+ - tei_count
+
+### Development
+This library implements the semantic release setup, which means that version numbers are not manually maintained but
+derived from the commit/PR history.
+
+Branches:
+- `main`: a push to `main` branch will trigger a new production release (both Maven and NPMJS).
+- `beta`: a push to `beta` branch will trigger a SNAPSHOT release in Maven and a new beta release in NPMJS.
+
+Version number are determined by the presence of commits with these suffixes:
+- `fix:`: it will increase the patch number.
+- `feat:`: it will increase the minor version number.
+- `feat!:`: it will increase the major version number.
+
+If there is not any commit with any of this tags between the previous version and the current commit, nothing will be published.
+
+Typical workflow:
+1. Do work in a feature branch. There is no need to add tags to the commits.
+2. Create a PR to `beta` branch including a tag in the PR title depending on the kind of changes.
+3. Merge the PR using **Squash and merge**. It will publish a SNAPSHOT/BETA release if there is a version change.
+4. Create a PR to `main` branch. Once merged, it will publish a production release.
 
 ---
 WIP


### PR DESCRIPTION
Updates readme file to includes the development section.

Adds the signing keys for the publish plugin.

This PR does not contain "fix:" or "feat:" not to trigger a new publication.