### PR TITLE
fix: javadoc classifier and sign dependency

### DIFF
--- a/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
@@ -15,7 +15,7 @@ val dokkaHtml = tasks.findByName("dokkaHtml")!!
 val dokkaHtmlJar = tasks.register<Jar>("dokkaHtmlJar") {
     dependsOn(dokkaHtml)
     from(dokkaHtml.outputs)
-    archiveClassifier.set("docs")
+    archiveClassifier.set("javadoc")
 }
 
 publishing {
@@ -71,4 +71,11 @@ signing {
     setRequired({ !version.toString().endsWith("-SNAPSHOT") })
     useInMemoryPgpKeys(signingPrivateKey, signingPassword)
     sign(publishing.publications)
+}
+
+// Fix Gradle warning about signing tasks using publishing task outputs without explicit dependencies
+// https://github.com/gradle/gradle/issues/26091
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    val signingTasks = tasks.withType<Sign>()
+    mustRunAfter(signingTasks)
 }


### PR DESCRIPTION
Adds the "javadoc" classifier to meet Nexus requirements.

Includes a workaround for this issue https://github.com/gradle/gradle/issues/26091