### PR TITLE
fix: Get environment from expected function

### DIFF
--- a/src/commonMain/kotlin/org/hisp/dhis/rules/Environment.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/Environment.kt
@@ -1,0 +1,3 @@
+package org.hisp.dhis.rules
+
+expect fun getEnvironment(): String

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
@@ -8,6 +8,7 @@ import org.hisp.dhis.lib.expression.spi.ValueType
 import org.hisp.dhis.rules.api.DataItem
 import org.hisp.dhis.rules.api.RuleEngine
 import org.hisp.dhis.rules.api.RuleEngineContext
+import org.hisp.dhis.rules.getEnvironment
 import org.hisp.dhis.rules.models.*
 
 internal class DefaultRuleEngine: RuleEngine {
@@ -15,7 +16,7 @@ internal class DefaultRuleEngine: RuleEngine {
         val valueMap = RuleVariableValueMapBuilder.target(target)
             .ruleVariables(executionContext.ruleVariables)
             .ruleEnrollment(ruleEnrollment)
-            .triggerEnvironment(TriggerEnvironment.SERVER)
+            .triggerEnvironment(TriggerEnvironment.valueOf(getEnvironment()))
             .ruleEvents(ruleEvents)
             .constantValueMap(executionContext.constantsValues)
             .build()
@@ -28,7 +29,7 @@ internal class DefaultRuleEngine: RuleEngine {
     override fun evaluate(target: RuleEnrollment, ruleEvents: List<RuleEvent>, executionContext: RuleEngineContext): List<RuleEffect> {
         val valueMap = RuleVariableValueMapBuilder.target(target)
                 .ruleVariables(executionContext.ruleVariables)
-                .triggerEnvironment(TriggerEnvironment.SERVER)
+                .triggerEnvironment(TriggerEnvironment.valueOf(getEnvironment()))
                 .ruleEvents(ruleEvents)
                 .constantValueMap(executionContext.constantsValues)
                 .build()
@@ -42,7 +43,7 @@ internal class DefaultRuleEngine: RuleEngine {
         val valueMap = RuleVariableValueMapBuilder.target()
                 .ruleVariables(executionContext.ruleVariables)
                 .ruleEnrollment(enrollmentTarget)
-                .triggerEnvironment(TriggerEnvironment.SERVER)
+                .triggerEnvironment(TriggerEnvironment.valueOf(getEnvironment()))
                 .ruleEvents(eventsTarget)
                 .constantValueMap(executionContext.constantsValues)
                 .multipleBuild()

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/TriggerEnvironment.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/TriggerEnvironment.kt
@@ -1,4 +1,7 @@
 package org.hisp.dhis.rules.models
+
+import kotlin.js.JsExport
+
 /*
  * Copyright (c) 2004-2018, University of Oslo
  * All rights reserved.
@@ -30,8 +33,10 @@ package org.hisp.dhis.rules.models
 /**
  * @author Zubair Asghar.
  */
+@JsExport
 enum class TriggerEnvironment(val clientName: String) {
     ANDROIDCLIENT("AndroidClient"),
-    SERVER("Server")
+    SERVER("Server"),
+    WEBCLIENT("WebClient")
 
 }

--- a/src/commonTest/kotlin/org/hisp/dhis/rules/ProgramRuleVariableTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/rules/ProgramRuleVariableTest.kt
@@ -89,7 +89,7 @@ class ProgramRuleVariableTest {
     fun testEnvironmentProgramVariableIsAssigned() {
         val rule = getRule("V{environment}")
         val ruleEffects = callEnrollmentRuleEngine(rule)
-        assertProgramRuleVariableAssignment(ruleEffects, rule, "Server")
+        assertProgramRuleVariableAssignment(ruleEffects, rule, TriggerEnvironment.valueOf(getEnvironment()).clientName)
     }
 
     @Test

--- a/src/jsMain/kotlin/org/hisp/dhis/rules/Environment.js.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/rules/Environment.js.kt
@@ -1,0 +1,5 @@
+package org.hisp.dhis.rules
+
+actual fun getEnvironment(): String {
+    return "WEBCLIENT"
+}

--- a/src/jvmMain/kotlin/org/hisp/dhis/rules/Environment.jvm.kt
+++ b/src/jvmMain/kotlin/org/hisp/dhis/rules/Environment.jvm.kt
@@ -1,0 +1,5 @@
+package org.hisp.dhis.rules
+
+actual fun getEnvironment(): String {
+    return "SERVER"
+}

--- a/src/nativeMain/kotlin/org/hisp/dhis/rules/Environment.native.kt
+++ b/src/nativeMain/kotlin/org/hisp/dhis/rules/Environment.native.kt
@@ -1,0 +1,5 @@
+package org.hisp.dhis.rules
+
+actual fun getEnvironment(): String {
+    return "ANDROIDCLIENT"
+}


### PR DESCRIPTION
`TriggerEnvironment` is hardcoded to `SERVER` in rule-engine and this is an issue as it is used to calculate the value of the `ProgramRuleVariable` `#{environment}` that can be used in expressions.
This was always an issue between `Server` and `Android` but not for `Web` as rule-engine wasn't a shared library.

Now we need to make it work correctly.

In this PR, I created an expected function to calculate the correct environment that is implemented in all the different platforms `Js`, `Jvm` and `Native`.

We cannot really assume the client from the `platform` they are using as a server can be implemented in JavaScript and `Jvm` library can be importer by Android.

Next step could be to have the `TriggerEnvironment` as an optional value that if not defined will be set to the current environment?