### PR TITLE
[skip publish] Remove SNAPSHOT suffix from production release to NPMJS

### DIFF
--- a/.github/workflows/scripts/publish-npm-prod.sh
+++ b/.github/workflows/scripts/publish-npm-prod.sh
@@ -1,7 +1,7 @@
 set -x
 
-./gradlew packJsPackage
-./gradlew packJsPackage -PuseCommonJs
+./gradlew packJsPackage -PremoveSnapshotSuffix
+./gradlew packJsPackage -PremoveSnapshotSuffix -PuseCommonJs
 
 cd build/packages/js || exit
 


### PR DESCRIPTION
The script to deploy the JS library to NPMJS (production mode) was missing the property to remove the SNAPSHOT suffix. 

This PR does not generate a new version.