### PR TITLE
refactor: reduce code complexity

### DIFF
--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleVariable.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleVariable.kt
@@ -16,10 +16,7 @@ interface RuleVariable {
     ): RuleVariableValue
 
     fun getOptionName(value: String): String {
-        // if no option found then existing value in the context will be used
         return options
-            .filter { (_, code): Option -> value == code }
-            .map(Option::name)
-            .getOrElse(0) { _ -> value }
+            .find { (_, code): Option -> value == code }?.name ?: value
     }
 }


### PR DESCRIPTION
When the option list is too large the `getOptionName` method takes a lot of time in android. Using _find_ extension function will reduce the number of loops to handle the list.