### PR TITLE
fix: Use slf4j as log manager for jvm

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
 }
 
-version = "3.2.0-SNAPSHOT"
+version = "3.2.1-SNAPSHOT"
 group = "org.hisp.dhis.rules"
 
 if (project.hasProperty("removeSnapshotSuffix")) {
@@ -67,7 +67,11 @@ kotlin {
                 implementation(kotlin("test"))
             }
         }
-        val jvmMain by getting
+        val jvmMain by getting {
+            dependencies {
+                api("org.slf4j:slf4j-api:1.7.36")
+            }
+        }
         val jvmTest by getting
         val jsMain by getting {
             dependencies {

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
@@ -220,6 +220,6 @@ internal class RuleConditionEvaluator {
     }
 
     companion object {
-        private val log = createLogger(RuleConditionEvaluator::class.simpleName!!)
+        private val log = createLogger("org.hisp.dhis.rules.engine.RuleConditionEvaluator")
     }
 }

--- a/src/jvmMain/kotlin/org/hisp/dhis/rules/Logger.kt
+++ b/src/jvmMain/kotlin/org/hisp/dhis/rules/Logger.kt
@@ -1,6 +1,8 @@
 package org.hisp.dhis.rules
 
+import org.slf4j.LoggerFactory
+
 actual fun createLogger(className: String): Logger{
-    val javaLogger = java.util.logging.Logger.getLogger(className)
-    return Logger({message -> javaLogger.severe(message)}, {message: String -> javaLogger.fine(message)})
+    val javaLogger = LoggerFactory.getLogger(className)
+    return Logger({message -> javaLogger.error(message)}, {message: String -> javaLogger.debug(message)})
 }


### PR DESCRIPTION
Use Log4J to log as it is the one used in dhis-core.