### PR TITLE
feat: Add support for d2:contains and d2:containsItems functions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
 }
 
-version = "3.3.0-SNAPSHOT"
+version = "3.3.1-SNAPSHOT"
 group = "org.hisp.dhis.rules"
 
 if (project.hasProperty("removeSnapshotSuffix")) {
@@ -58,7 +58,7 @@ kotlin {
         }
         val commonMain by getting {
             dependencies {
-                implementation("org.hisp.dhis.lib.expression:expression-parser:1.1.3")
+                implementation("org.hisp.dhis.lib.expression:expression-parser:1.1.4")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.1")
             }
         }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16911
PR bumps the version of expression parser to support `d2:contains` and `d2:containsItems` functions.
