### PR TITLE
fix: change default value of `priority` to `null`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
 }
 
-version = "3.3.9-SNAPSHOT"
+version = "3.3.10-SNAPSHOT"
 group = "org.hisp.dhis.rules"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/Rule.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/Rule.kt
@@ -6,7 +6,7 @@ data class Rule(
     val uid: String = "",
     val name: String? = null,
     val programStage: String? = null,
-    val priority: Int? = 0,
+    val priority: Int? = null,
 ) : Comparable<Rule> {
     override fun compareTo(other: Rule): Int =
         if (this.priority != null && other.priority != null) {

--- a/src/jsMain/kotlin/org/hisp/dhis/rules/RuleJs.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/rules/RuleJs.kt
@@ -7,5 +7,5 @@ data class RuleJs(
     val uid: String = "",
     val name: String? = null,
     val programStage: String? = null,
-    val priority: Int? = 0
+    val priority: Int? = null
 )


### PR DESCRIPTION
Program rules **without** priority should be executed after the program rules **with** priority.

By using priority `0` when no priority is given, the associated program rule will under normal circumstances be executed before all other program rules (incorrect behavior).

Changing the default value to `null` makes the affected program rules execute after program rules with priority (correct behavior).