### PR TITLE
chore: [skip publish] Adapt to Sonatype Central Publisher Portal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Publish Maven
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -PremoveSnapshotSuffix
         env:
-          OSSRH_USERNAME: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
+          SONATYPE_PORTAL_USERNAME: ${{ secrets.SONATYPE_PORTAL_USERNAME }}
+          SONATYPE_PORTAL_PASSWORD: ${{ secrets.SONATYPE_PORTAL_PASSWORD }}
           SIGNING_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
           SIGNING_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,5 +45,5 @@ jobs:
       - name: Publish Maven Snapshot
         run: ./gradlew publishToSonatype
         env:
-          OSSRH_USERNAME: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
+          SONATYPE_PORTAL_USERNAME: ${{ secrets.SONATYPE_PORTAL_USERNAME }}
+          SONATYPE_PORTAL_PASSWORD: ${{ secrets.SONATYPE_PORTAL_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
 }
 
 version = "3.3.10-SNAPSHOT"

--- a/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
@@ -5,8 +5,8 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
-val ossrhUsername: String? = System.getenv("OSSRH_USERNAME")
-val ossrhPassword: String? = System.getenv("OSSRH_PASSWORD")
+val centralPortalUsername: String? = System.getenv("SONATYPE_PORTAL_USERNAME")
+val centralPortalPassword: String? = System.getenv("SONATYPE_PORTAL_PASSWORD")
 val signingPrivateKey: String? = System.getenv("SIGNING_PRIVATE_KEY")
 val signingPassword: String? = System.getenv("SIGNING_PASSWORD")
 
@@ -61,8 +61,10 @@ publishing {
 nexusPublishing {
     this.repositories {
         sonatype {
-            username.set(ossrhUsername)
-            password.set(ossrhPassword)
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username.set(centralPortalUsername)
+            password.set(centralPortalPassword)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ apiCompatibility ="0.17.0"
 kotlinxDatetime = "0.6.1"
 kotlinJsWrappers = "1.0.0-pre.830"
 slf4jApi = "1.7.36"
-expressionParser = "1.1.10"
+expressionParser = "1.1.11"
 
 [libraries]
 kotlin-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
This PR adapts the publishing configuration to the new Central Publisher Portal.

The version is not increased and this PR won't generate a release (it has `[skip publish]` on the title). 