### PR TITLE
chore: [skip publish] Update maven central badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.hisp.dhis.rules/rule-engine/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.hisp.dhis.rules/rule-engine)
+[![Maven Central](https://img.shields.io/maven-central/v/org.hisp.dhis.rules/rule-engine?label=maven%20central)](https://central.sonatype.com/artifact/org.hisp.dhis.rules/rule-engine)
 [![NPM Version](https://img.shields.io/npm/v/@dhis2/rule-engine)](https://www.npmjs.com/package/@dhis2/rule-engine)
 [![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://dhis2.github.io/dhis2-rule-engine/api/)
 


### PR DESCRIPTION
This PR updates the maven central bagde in the readme file that shows the latest published version of the Rule Engine.

The publishing is skipped.