### PR TITLE
fix: Always create supplementary data value keys [DHIS2-19426]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
 }
 
-version = "3.4.0-SNAPSHOT"
+version = "3.4.1-SNAPSHOT"
 group = "org.hisp.dhis.rules"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
@@ -172,13 +172,9 @@ internal class RuleConditionEvaluator {
 
     private fun convertSupplementaryData(ruleSupplementaryData: RuleSupplementaryData): Map<String, List<String>> {
         val supplementaryValues: MutableMap<String, List<String>> = HashMap()
-        if(ruleSupplementaryData.userGroups.isNotEmpty()) {
-            supplementaryValues["USER_GROUPS"] = ruleSupplementaryData.userGroups
-        }
-        if(ruleSupplementaryData.userRoles.isNotEmpty()) {
-            supplementaryValues["USER_ROLES"] = ruleSupplementaryData.userRoles
-        }
 
+        supplementaryValues["USER_GROUPS"] = ruleSupplementaryData.userGroups
+        supplementaryValues["USER_ROLES"] = ruleSupplementaryData.userRoles
         supplementaryValues.putAll(ruleSupplementaryData.orgUnitGroups)
 
         return supplementaryValues

--- a/src/commonTest/kotlin/org/hisp/dhis/rules/RuleEngineFunctionTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/rules/RuleEngineFunctionTest.kt
@@ -734,7 +734,7 @@ class RuleEngineFunctionTest {
         val userGroups = listOf("member1", "member2")
         val ruleAction =
             RuleAction(
-                "d2:inUserGroup('member1')",
+                "",
                 "DISPLAYTEXT",
                 mapOf(Pair("content", "test_action_content"), Pair("location", "feedback")),
             )
@@ -746,7 +746,7 @@ class RuleEngineFunctionTest {
                 "test_data_element_one",
                 RuleValueType.TEXT,
             )
-        val rule = Rule("true", listOf(ruleAction), "", "")
+        val rule = Rule("d2:inUserGroup('member1')", listOf(ruleAction), "", "")
         val ruleEngineContext =
             RuleEngineContext(
                 rules = listOf(rule),
@@ -770,6 +770,40 @@ class RuleEngineFunctionTest {
         val ruleEffects = RuleEngine.getInstance().evaluate(ruleEvent, null, emptyList(), ruleEngineContext)
         assertEquals(1, ruleEffects.size)
         assertEquals(ruleAction, ruleEffects[0].ruleAction)
+    }
+
+    @Test
+    fun evaluateInUserGroupWhenSupplementaryIsEmpty() {
+        val ruleAction =
+            RuleAction(
+                "",
+                "DISPLAYTEXT",
+                mapOf(Pair("content", "test_action_content"), Pair("location", "feedback")),
+            )
+        val rule = Rule("d2:inUserGroup('member1')", listOf(ruleAction), "", "")
+        val ruleEngineContext =
+            RuleEngineContext(
+                rules = listOf(rule),
+                ruleVariables = listOf(),
+                ruleSupplementaryData = RuleSupplementaryData()
+            )
+        val ruleEvent =
+            RuleEvent(
+                "test_event",
+                "test_program_stage",
+                "",
+                RuleEventStatus.ACTIVE,
+                RuleInstant.now(),
+                RuleInstant.now(),
+                RuleLocalDate.currentDate(),
+                null,
+                "location1",
+                null,
+                emptyList()
+            )
+        val ruleEffects = RuleEngine.getInstance().evaluateAll(null, listOf(ruleEvent), ruleEngineContext)
+        assertEquals(1, ruleEffects.size)
+        assertEquals(0, getRuleEffectsByUid(ruleEffects, "test_event")?.ruleEffects?.size)
     }
 
     @Test


### PR DESCRIPTION
There was an issue in last PR about supplementary data values.
We need to always create the keys for the supplementary data values map that is passed to expression parser otherwise an exception will be raised when evaluating the functions that need values in the supplementary data map.