### PR TITLE
fix: [DHIS2-20696] update expression-parser to 1.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
 }
 
-version = "3.4.1-SNAPSHOT"
+version = "3.4.2-SNAPSHOT"
 group = "org.hisp.dhis.rules"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ apiCompatibility ="0.17.0"
 kotlinxDatetime = "0.7.1"
 kotlinJsWrappers = "1.0.0-pre.830"
 slf4jApi = "1.7.36"
-expressionParser = "1.3.0"
+expressionParser = "1.3.1"
 
 [libraries]
 kotlin-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
Adds support for `d2:minutesBetween` in the rule engine.