### PR TITLE
feat: Order rule action by new priority field [DHIS2-20758]

### DIFF
--- a/api/rule-engine.api
+++ b/api/rule-engine.api
@@ -177,19 +177,23 @@ public final class org/hisp/dhis/rules/models/Rule : java/lang/Comparable {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class org/hisp/dhis/rules/models/RuleAction {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class org/hisp/dhis/rules/models/RuleAction : java/lang/Comparable {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun attributeType ()Ljava/lang/String;
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Lorg/hisp/dhis/rules/models/RuleAction;)I
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/Integer;
 	public final fun content ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lorg/hisp/dhis/rules/models/RuleAction;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/rules/models/RuleAction;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lorg/hisp/dhis/rules/models/RuleAction;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;)Lorg/hisp/dhis/rules/models/RuleAction;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/rules/models/RuleAction;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/hisp/dhis/rules/models/RuleAction;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun field ()Ljava/lang/String;
 	public final fun getData ()Ljava/lang/String;
+	public final fun getPriority ()Ljava/lang/Integer;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getValues ()Ljava/util/Map;
 	public fun hashCode ()I

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
 }
 
-version = "3.4.2-SNAPSHOT"
+version = "3.5.0-SNAPSHOT"
 group = "org.hisp.dhis.rules"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
@@ -65,7 +65,7 @@ internal class RuleConditionEvaluator {
                         ExpressionMode.RULE_ENGINE_CONDITION,
                     ).toBoolean()
                 ) {
-                    for (action in rule.actions) {
+                    for (action in rule.actions.sorted()) {
                         try {
                             // Check if action is assigning value to calculated variable
                             if (isAssignToCalculatedValue(action)) {

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleAction.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleAction.kt
@@ -4,10 +4,27 @@ data class RuleAction(
     val data: String?,
     val type: String,
     val values: Map<String, String> = emptyMap(),
-) {
+    val priority: Int? = null,
+) : Comparable<RuleAction> {
     fun content(): String? = values["content"]
 
     fun field(): String? = values["field"]
 
     fun attributeType(): String? = values["attributeType"]
+
+    override fun compareTo(other: RuleAction): Int =
+        when {
+            this.priority != null && other.priority != null -> {
+                this.priority.compareTo(other.priority)
+            }
+            this.priority != null -> {
+                -1
+            }
+            other.priority != null -> {
+                1
+            }
+            else -> {
+                0
+            }
+        }
 }

--- a/src/commonTest/kotlin/org/hisp/dhis/rules/OrderedRulesTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/rules/OrderedRulesTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.rules
+
+import org.hisp.dhis.rules.api.RuleEngine
+import org.hisp.dhis.rules.api.RuleEngineContext
+import org.hisp.dhis.rules.models.Rule
+import org.hisp.dhis.rules.models.RuleAction
+import org.hisp.dhis.rules.models.RuleAttributeValue
+import org.hisp.dhis.rules.models.RuleEnrollment
+import org.hisp.dhis.rules.models.RuleEnrollmentStatus
+import org.hisp.dhis.rules.models.RuleEvent
+import org.hisp.dhis.rules.models.RuleLocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OrderedRulesTest {
+    @Test
+    fun shouldEvaluateRulesOrderedByPriority() {
+        val highPriorityRuleAction = RuleAction("1", "SHOWERROR")
+        val lowPriorityRuleAction = RuleAction("2", "SHOWERROR")
+        val nullPriorityRuleAction = RuleAction("3", "SHOWERROR")
+        val highPriorityRule = Rule("true", listOf(highPriorityRuleAction), priority = 1)
+        val lowPriorityRule = Rule("true", listOf(lowPriorityRuleAction), priority = 100)
+        val nullPriorityRule = Rule("true", listOf(nullPriorityRuleAction), priority = null)
+
+        val ruleEngineContext = RuleEngineContext(listOf(lowPriorityRule, nullPriorityRule, highPriorityRule))
+
+        val effects = RuleEngine.getInstance().evaluate(enrollment(), listOf(), ruleEngineContext)
+
+        assertEquals(highPriorityRuleAction.data, effects[0].data)
+        assertEquals(lowPriorityRuleAction.data, effects[1].data)
+        assertEquals(nullPriorityRuleAction.data, effects[2].data)
+    }
+
+    @Test
+    fun shouldEvaluateRulesAndRuleActionsOrderedByPriority() {
+        val highPriorityRuleActionInHighPriorityRule = RuleAction("1", "SHOWERROR", priority = 1)
+        val lowPriorityRuleActionInHighPriorityRule = RuleAction("2", "SHOWERROR", priority = 100)
+        val nullPriorityRuleActionInHighPriorityRule = RuleAction("3", "SHOWERROR", priority = null)
+        val highPriorityRuleActionInLowPriorityRule = RuleAction("4", "SHOWERROR", priority = 1)
+        val lowPriorityRuleActionInLowPriorityRule = RuleAction("5", "SHOWERROR", priority = 100)
+        val nullPriorityRuleActionInLowPriorityRule = RuleAction("6", "SHOWERROR", priority = null)
+        val highPriorityRuleActionInNullPriorityRule = RuleAction("7", "SHOWERROR", priority = 1)
+        val lowPriorityRuleActionInNullPriorityRule = RuleAction("8", "SHOWERROR", priority = 100)
+        val nullPriorityRuleActionInNullPriorityRule = RuleAction("9", "SHOWERROR", priority = null)
+        val highPriorityRule = Rule("true", listOf(highPriorityRuleActionInHighPriorityRule,
+                lowPriorityRuleActionInHighPriorityRule,
+                nullPriorityRuleActionInHighPriorityRule), priority = 1)
+        val lowPriorityRule = Rule("true", listOf(highPriorityRuleActionInLowPriorityRule,
+            lowPriorityRuleActionInLowPriorityRule,
+            nullPriorityRuleActionInLowPriorityRule), priority = 100)
+        val nullPriorityRule = Rule("true", listOf(highPriorityRuleActionInNullPriorityRule,
+            lowPriorityRuleActionInNullPriorityRule,
+            nullPriorityRuleActionInNullPriorityRule), priority = null)
+
+        val ruleEngineContext = RuleEngineContext(listOf(lowPriorityRule, nullPriorityRule, highPriorityRule))
+
+        val effects = RuleEngine.getInstance().evaluate(enrollment(), listOf(), ruleEngineContext)
+
+        assertEquals(highPriorityRuleActionInHighPriorityRule.data, effects[0].data)
+        assertEquals(lowPriorityRuleActionInHighPriorityRule.data, effects[1].data)
+        assertEquals(nullPriorityRuleActionInHighPriorityRule.data, effects[2].data)
+
+        assertEquals(highPriorityRuleActionInLowPriorityRule.data, effects[3].data)
+        assertEquals(lowPriorityRuleActionInLowPriorityRule.data, effects[4].data)
+        assertEquals(nullPriorityRuleActionInLowPriorityRule.data, effects[5].data)
+
+        assertEquals(highPriorityRuleActionInNullPriorityRule.data, effects[6].data)
+        assertEquals(lowPriorityRuleActionInNullPriorityRule.data, effects[7].data)
+        assertEquals(nullPriorityRuleActionInNullPriorityRule.data, effects[8].data)
+    }
+
+    private fun enrollment(): RuleEnrollment {
+        return RuleEnrollment(
+            enrollment = "test_enrollment",
+            programName = "test_program",
+            incidentDate = RuleLocalDate.currentDate(),
+            enrollmentDate = RuleLocalDate.currentDate(),
+            status = RuleEnrollmentStatus.ACTIVE,
+            organisationUnit = "test_ou",
+            organisationUnitCode = "test_ou_code",
+            attributeValues = listOf(RuleAttributeValue("test_attribute", "test_value")),
+        )
+    }
+}

--- a/src/jsMain/kotlin/org/hisp/dhis/rules/RuleActionJs.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/rules/RuleActionJs.kt
@@ -6,5 +6,6 @@ import js.collections.JsMap
 data class RuleActionJs(
     val data: String?,
     val type: String,
-    val values: JsMap<String, String> = JsMap()
+    val values: JsMap<String, String> = JsMap(),
+    val priority: Int? = null,
 )

--- a/src/jsMain/kotlin/org/hisp/dhis/rules/RuleEngineJs.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/rules/RuleEngineJs.kt
@@ -103,7 +103,8 @@ class RuleEngineJs(verbose: Boolean = false) {
         return RuleAction(
             data = ruleAction.data,
             type = ruleAction.type,
-            values = toMap(ruleAction.values, {it}, {it})
+            values = toMap(ruleAction.values, {it}, {it}),
+            priority = ruleAction.priority
         )
     }
 
@@ -128,7 +129,8 @@ class RuleEngineJs(verbose: Boolean = false) {
         return RuleActionJs(
             data = ruleAction.data,
             type = ruleAction.type,
-            values = JsMap(ruleAction.values.entries.map { e -> tupleOf(e.key, e.value) }.toTypedArray())
+            values = JsMap(ruleAction.values.entries.map { e -> tupleOf(e.key, e.value) }.toTypedArray()),
+            priority = ruleAction.priority
         )
     }
 


### PR DESCRIPTION
Use new `priority` field in `RuleAction` to order `List<RuleEffect>` returned by `evaluate` method.

`Rule`s already had a `priority` field and the evaluation was already ordered using it, now we have the same logic for `RuleAction`s.

Smaller values of `priority` will be evaluated first, `null` priority is evaluated last, as it is already happening for `Rule`s.

The change in the API is a breaking change for Java API but for Kotlin and Js (?) it is not a breaking change because the default value is `null` and the parameter was added as last parameter.