### PR TITLE
fix: Filter rules for different program stages [DHIS2-19862]

### DIFF
--- a/api/rule-engine.api
+++ b/api/rule-engine.api
@@ -549,11 +549,6 @@ public final class org/hisp/dhis/rules/models/TriggerEnvironment : java/lang/Enu
 	public static fun values ()[Lorg/hisp/dhis/rules/models/TriggerEnvironment;
 }
 
-public final class org/hisp/dhis/rules/utils/RuleEventUtilsKt {
-	public static final fun getPreviousDataValue (Ljava/util/List;Lorg/hisp/dhis/rules/models/RuleEvent;)Lorg/hisp/dhis/rules/models/RuleDataValueHistory;
-	public static final fun orderEvents (Ljava/util/Collection;)Ljava/util/List;
-}
-
 public final class org/hisp/dhis/rules/utils/UtilsKt {
 	public static final fun currentDate ()Lkotlinx/datetime/LocalDate;
 	public static final fun unwrapVariableName (Ljava/lang/String;)Ljava/lang/String;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
 }
 
-version = "3.6.0-SNAPSHOT"
+version = "3.6.1-SNAPSHOT"
 group = "org.hisp.dhis.rules"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
@@ -9,6 +9,7 @@ import org.hisp.dhis.rules.api.DataItem
 import org.hisp.dhis.rules.api.RuleEngine
 import org.hisp.dhis.rules.api.RuleEngineContext
 import org.hisp.dhis.rules.models.*
+import org.hisp.dhis.rules.utils.filterRules
 import org.hisp.dhis.rules.utils.orderEvents
 
 internal class DefaultRuleEngine : RuleEngine {
@@ -31,7 +32,7 @@ internal class DefaultRuleEngine : RuleEngine {
             target.event,
             valueMap,
             executionContext.ruleSupplementaryData,
-            executionContext.rules,
+            filterRules(executionContext.rules, target),
         )
     }
 
@@ -52,7 +53,7 @@ internal class DefaultRuleEngine : RuleEngine {
             target.enrollment,
             valueMap,
             executionContext.ruleSupplementaryData,
-            executionContext.rules,
+            filterRules(executionContext.rules),
         )
     }
 

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleEngineMultipleExecution.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleEngineMultipleExecution.kt
@@ -2,6 +2,7 @@ package org.hisp.dhis.rules.engine
 
 import org.hisp.dhis.rules.api.RuleSupplementaryData
 import org.hisp.dhis.rules.models.*
+import org.hisp.dhis.rules.utils.filterRules
 
 internal class RuleEngineMultipleExecution {
     fun execute(
@@ -44,56 +45,5 @@ internal class RuleEngineMultipleExecution {
             )
         }
         return ruleEffects
-    }
-
-    private fun filterRules(rules: List<Rule>): List<Rule> {
-        val filteredRules: MutableList<Rule> = mutableListOf()
-        for (rule in rules) {
-            val programStage: String? = rule.programStage
-            if (programStage.isNullOrEmpty()) {
-                val ruleActions =
-                    filterActionRules(
-                        rule.actions,
-                        AttributeType.TRACKED_ENTITY_ATTRIBUTE,
-                    )
-                filteredRules.add(rule.copy(actions = ruleActions))
-            }
-        }
-        return filteredRules
-    }
-
-    private fun filterRules(
-        rules: List<Rule>,
-        ruleEvent: RuleEvent,
-    ): List<Rule> {
-        val filteredRules: MutableList<Rule> = mutableListOf()
-        for (rule in rules) {
-            val programStage: String? = rule.programStage
-            if (programStage.isNullOrEmpty() || programStage == ruleEvent.programStage) {
-                val ruleActions =
-                    filterActionRules(
-                        rule.actions,
-                        AttributeType.DATA_ELEMENT,
-                    )
-                filteredRules.add(rule.copy(actions = ruleActions))
-            }
-        }
-        return filteredRules
-    }
-
-    private fun filterActionRules(
-        ruleActions: List<RuleAction>,
-        attributeType: AttributeType,
-    ): List<RuleAction> {
-        val filteredRuleActions: MutableList<RuleAction> = mutableListOf()
-        for (ruleAction in ruleActions) {
-            if (ruleAction.attributeType() == null ||
-                ruleAction.attributeType() == attributeType.name ||
-                ruleAction.attributeType() == AttributeType.UNKNOWN.name
-            ) {
-                filteredRuleActions.add(ruleAction)
-            }
-        }
-        return filteredRuleActions
     }
 }

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/utils/RuleEventUtils.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/utils/RuleEventUtils.kt
@@ -1,5 +1,8 @@
 package org.hisp.dhis.rules.utils
 
+import org.hisp.dhis.rules.models.AttributeType
+import org.hisp.dhis.rules.models.Rule
+import org.hisp.dhis.rules.models.RuleAction
 import org.hisp.dhis.rules.models.RuleDataValueHistory
 import org.hisp.dhis.rules.models.RuleEvent
 
@@ -31,11 +34,11 @@ import org.hisp.dhis.rules.models.RuleEvent
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-fun orderEvents(events: Collection<RuleEvent>): List<RuleEvent> {
+internal fun orderEvents(events: Collection<RuleEvent>): List<RuleEvent> {
     return events.sorted()
 }
 
-fun getPreviousDataValue(dataValues: List<RuleDataValueHistory>, ruleEvent: RuleEvent): RuleDataValueHistory? {
+internal fun getPreviousDataValue(dataValues: List<RuleDataValueHistory>, ruleEvent: RuleEvent): RuleDataValueHistory? {
     for (ruleDataValue in dataValues) {
         if (ruleEvent.eventDate > ruleDataValue.eventDate ||
             (ruleEvent.eventDate == ruleDataValue.eventDate && ruleEvent.resolvedCreatedDate > ruleDataValue.createdDate)
@@ -44,4 +47,55 @@ fun getPreviousDataValue(dataValues: List<RuleDataValueHistory>, ruleEvent: Rule
         }
     }
     return null
+}
+
+internal fun filterRules(rules: List<Rule>): List<Rule> {
+    val filteredRules: MutableList<Rule> = mutableListOf()
+    for (rule in rules) {
+        val programStage: String? = rule.programStage
+        if (programStage.isNullOrEmpty()) {
+            val ruleActions =
+                filterActionRules(
+                    rule.actions,
+                    AttributeType.TRACKED_ENTITY_ATTRIBUTE,
+                )
+            filteredRules.add(rule.copy(actions = ruleActions))
+        }
+    }
+    return filteredRules
+}
+
+internal fun filterRules(
+    rules: List<Rule>,
+    ruleEvent: RuleEvent,
+): List<Rule> {
+    val filteredRules: MutableList<Rule> = mutableListOf()
+    for (rule in rules) {
+        val programStage: String? = rule.programStage
+        if (programStage.isNullOrEmpty() || programStage == ruleEvent.programStage) {
+            val ruleActions =
+                filterActionRules(
+                    rule.actions,
+                    AttributeType.DATA_ELEMENT,
+                )
+            filteredRules.add(rule.copy(actions = ruleActions))
+        }
+    }
+    return filteredRules
+}
+
+private fun filterActionRules(
+    ruleActions: List<RuleAction>,
+    attributeType: AttributeType,
+): List<RuleAction> {
+    val filteredRuleActions: MutableList<RuleAction> = mutableListOf()
+    for (ruleAction in ruleActions) {
+        if (ruleAction.attributeType() == null ||
+            ruleAction.attributeType() == attributeType.name ||
+            ruleAction.attributeType() == AttributeType.UNKNOWN.name
+        ) {
+            filteredRuleActions.add(ruleAction)
+        }
+    }
+    return filteredRuleActions
 }

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/utils/RuleEventUtils.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/utils/RuleEventUtils.kt
@@ -88,14 +88,10 @@ private fun filterActionRules(
     ruleActions: List<RuleAction>,
     attributeType: AttributeType,
 ): List<RuleAction> {
-    val filteredRuleActions: MutableList<RuleAction> = mutableListOf()
-    for (ruleAction in ruleActions) {
-        if (ruleAction.attributeType() == null ||
-            ruleAction.attributeType() == attributeType.name ||
-            ruleAction.attributeType() == AttributeType.UNKNOWN.name
-        ) {
-            filteredRuleActions.add(ruleAction)
-        }
+    return ruleActions.filter {
+        it.attributeType() == null ||
+            it.attributeType() == attributeType.name ||
+            it.attributeType() == AttributeType.UNKNOWN.name
     }
-    return filteredRuleActions
+
 }

--- a/src/commonTest/kotlin/org/hisp/dhis/rules/RuleEngineFunctionTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/rules/RuleEngineFunctionTest.kt
@@ -54,6 +54,140 @@ class RuleEngineFunctionTest {
     }
 
     @Test
+    fun shouldRulesForSpecificProgramStageNotBeEvaluatedForEnrollment() {
+        val ruleAction = RuleAction(
+            "2 + 2",
+            "DISPLAYTEXT",
+            mapOf(Pair("content", "test_action_content"), Pair("location", "feedback"))
+        )
+        val rule =
+            Rule(
+                "true",
+                listOf(ruleAction),
+                "",
+                "",
+                programStage = "NpsdDv6kKSO"
+            )
+        val ruleEnrollment =
+            RuleEnrollment(
+                "test_enrollment",
+                "",
+                RuleLocalDate.currentDate(),
+                RuleLocalDate.currentDate(),
+                RuleEnrollmentStatus.ACTIVE,
+                "",
+                "",
+                listOf(),
+            )
+        val ruleEngineContext = RuleEngineTestUtils.getRuleEngineContext(listOf(rule))
+        val ruleEffects = RuleEngine.getInstance()
+            .evaluate(ruleEnrollment, listOf(), ruleEngineContext)
+        assertEquals(0, ruleEffects.size)
+    }
+
+    @Test
+    fun shouldRulesForSpecificProgramStageNotBeEvaluatedForEventWithDifferentProgramStage() {
+        val ruleAction = RuleAction(
+            "2 + 2",
+            "DISPLAYTEXT",
+            mapOf(Pair("content", "test_action_content"), Pair("location", "feedback"))
+        )
+        val rule =
+            Rule(
+                "true",
+                listOf(ruleAction),
+                "",
+                "",
+                programStage = "NpsdDv6kKSO"
+            )
+        val ruleEnrollment =
+            RuleEnrollment(
+                "test_enrollment",
+                "",
+                RuleLocalDate.currentDate(),
+                RuleLocalDate.currentDate(),
+                RuleEnrollmentStatus.ACTIVE,
+                "",
+                "",
+                listOf(),
+            )
+        val ruleEvent = RuleEvent(
+            "test_event",
+            "nxP7UnKhomJ",
+            "",
+            RuleEventStatus.ACTIVE,
+            RuleLocalDate.currentDate(),
+            RuleInstant.now(),
+            null,
+            RuleLocalDate.currentDate(),
+            null,
+            "",
+            null,
+            listOf(
+                RuleDataValue(
+                    "test_data_element_one",
+                    "condition",
+                ),
+            ),
+        )
+        val ruleEngineContext = RuleEngineTestUtils.getRuleEngineContext(listOf(rule))
+        val ruleEffects = RuleEngine.getInstance()
+            .evaluate(ruleEvent, ruleEnrollment, listOf(), ruleEngineContext)
+        assertEquals(0, ruleEffects.size)
+    }
+
+    @Test
+    fun shouldRulesForSpecificProgramStageBeEvaluatedForEventWithSameProgramStage() {
+        val ruleAction = RuleAction(
+            "2 + 2",
+            "DISPLAYTEXT",
+            mapOf(Pair("content", "test_action_content"), Pair("location", "feedback"))
+        )
+        val rule =
+            Rule(
+                "true",
+                listOf(ruleAction),
+                "",
+                "",
+                programStage = "NpsdDv6kKSO"
+            )
+        val ruleEnrollment =
+            RuleEnrollment(
+                "test_enrollment",
+                "",
+                RuleLocalDate.currentDate(),
+                RuleLocalDate.currentDate(),
+                RuleEnrollmentStatus.ACTIVE,
+                "",
+                "",
+                listOf(),
+            )
+        val ruleEvent = RuleEvent(
+            "test_event",
+            "NpsdDv6kKSO",
+            "",
+            RuleEventStatus.ACTIVE,
+            RuleLocalDate.currentDate(),
+            RuleInstant.now(),
+            null,
+            RuleLocalDate.currentDate(),
+            null,
+            "",
+            null,
+            listOf(
+                RuleDataValue(
+                    "test_data_element_one",
+                    "condition",
+                ),
+            ),
+        )
+        val ruleEngineContext = RuleEngineTestUtils.getRuleEngineContext(listOf(rule))
+        val ruleEffects = RuleEngine.getInstance()
+            .evaluate(ruleEvent, ruleEnrollment, listOf(), ruleEngineContext)
+        assertEquals(1, ruleEffects.size)
+    }
+
+    @Test
     fun evaluateFailingRuleInMultipleContext() {
         val today = currentDate()
         val yesterday = today.minus(1, DateTimeUnit.DAY).atStartOfDayIn(TimeZone.currentSystemDefault())


### PR DESCRIPTION
We were filtering rules based on program stages only when doing multiple evaluation.
Now we are filtering:
- when evaluating an event, we are filtering out all the rules that are linked to a different program stage
- when evaluating an enrollment, we are filtering out all the rules that are linked to a program stage 