### PR TITLE
fix: Fix evaluation of null event date

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,6 @@ jobs:
           node-version: 24
 
       - name: Publish Maven
-        if: false
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -PremoveSnapshotSuffix
         env:
           SONATYPE_PORTAL_USERNAME: ${{ secrets.SONATYPE_PORTAL_USERNAME }}

--- a/api/rule-engine.api
+++ b/api/rule-engine.api
@@ -391,6 +391,7 @@ public final class org/hisp/dhis/rules/models/RuleLocalDate : java/lang/Comparab
 	public final fun copy (III)Lorg/hisp/dhis/rules/models/RuleLocalDate;
 	public static synthetic fun copy$default (Lorg/hisp/dhis/rules/models/RuleLocalDate;IIIILjava/lang/Object;)Lorg/hisp/dhis/rules/models/RuleLocalDate;
 	public static final fun currentDate ()Lorg/hisp/dhis/rules/models/RuleLocalDate;
+	public static final fun distantFuture ()Lorg/hisp/dhis/rules/models/RuleLocalDate;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDay ()I
 	public final fun getMonth ()I
@@ -401,6 +402,7 @@ public final class org/hisp/dhis/rules/models/RuleLocalDate : java/lang/Comparab
 
 public final class org/hisp/dhis/rules/models/RuleLocalDate$Companion {
 	public final fun currentDate ()Lorg/hisp/dhis/rules/models/RuleLocalDate;
+	public final fun distantFuture ()Lorg/hisp/dhis/rules/models/RuleLocalDate;
 	public final fun parse (Ljava/lang/String;)Lorg/hisp/dhis/rules/models/RuleLocalDate;
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
 }
 
-version = "3.7.0-SNAPSHOT"
+version = "3.7.1-SNAPSHOT"
 group = "org.hisp.dhis.rules"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
@@ -1,13 +1,10 @@
 package org.hisp.dhis.rules.engine
 
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
 import org.hisp.dhis.rules.models.*
 import org.hisp.dhis.rules.utils.RuleEngineUtils
 import org.hisp.dhis.rules.utils.currentDate
 import org.hisp.dhis.rules.utils.orderEvents
-import kotlin.time.Instant
 
 
 internal class RuleVariableValueMapBuilder {
@@ -134,7 +131,7 @@ internal class RuleVariableValueMapBuilder {
     ): Map<String, RuleVariableValue> {
         val valueMap: MutableMap<String, RuleVariableValue> = HashMap()
             val eventDate =
-                if (ruleEvent.eventDate.localDate.atStartOfDayIn(TimeZone.currentSystemDefault()) < Instant.DISTANT_FUTURE )
+                if (ruleEvent.eventDate < RuleLocalDate.distantFuture() )
                 ruleEvent.eventDate.toString()
             else null
             valueMap[RuleEngineUtils.ENV_VAR_EVENT_DATE] =

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleLocalDate.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleLocalDate.kt
@@ -1,11 +1,14 @@
 package org.hisp.dhis.rules.models
 
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
 import kotlinx.datetime.number
+import kotlinx.datetime.toLocalDateTime
 import kotlin.js.ExperimentalJsStatic
 import kotlin.js.JsExport
 import kotlin.js.JsStatic
 import kotlin.jvm.JvmStatic
+import kotlin.time.Instant
 
 @JsExport
 data class RuleLocalDate(val year: Int, val month: Int, val day: Int): Comparable<RuleLocalDate> {
@@ -28,6 +31,12 @@ data class RuleLocalDate(val year: Int, val month: Int, val day: Int): Comparabl
         @JsStatic
         fun parse(dateString: String): RuleLocalDate {
             return fromLocalDate(LocalDate.parse(dateString))
+        }
+
+        @JvmStatic
+        @JsStatic
+        fun distantFuture(): RuleLocalDate {
+            return fromLocalDate(Instant.DISTANT_FUTURE.toLocalDateTime(TimeZone.currentSystemDefault()).date)
         }
 
         internal fun fromLocalDate(localDate: LocalDate): RuleLocalDate {

--- a/src/commonTest/kotlin/org/hisp/dhis/rules/ProgramRuleVariableTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/rules/ProgramRuleVariableTest.kt
@@ -127,6 +127,17 @@ class ProgramRuleVariableTest {
     }
 
     @Test
+    fun testEventDateAsDistantFutureIsAssignedAsNull() {
+        val rule = getRule("V{event_date}")
+        val ruleEffects = callEventRuleEngine(rule, RuleLocalDate.distantFuture())
+        assertProgramRuleVariableAssignment(
+            ruleEffects,
+            rule,
+            null,
+        )
+    }
+
+    @Test
     fun testEventIdProgramVariableIsAssigned() {
         val rule = getRule("V{event_id}")
         val ruleEffects = callEventRuleEngine(rule)
@@ -225,7 +236,7 @@ class ProgramRuleVariableTest {
     private fun assertProgramRuleVariableAssignment(
         ruleEffects: List<RuleEffect>,
         rule: Rule,
-        variableValue: String,
+        variableValue: String?,
     ) {
         assertEquals(1, ruleEffects.size)
         assertEquals(variableValue, ruleEffects[0].data)
@@ -237,7 +248,7 @@ class ProgramRuleVariableTest {
         return RuleEngine.getInstance().evaluate(enrollment, emptyList(), ruleEngineContext)
     }
 
-    private fun callEventRuleEngine(rule: Rule): List<RuleEffect> {
+    private fun callEventRuleEngine(rule: Rule, eventDate: RuleLocalDate = EVENT_DATE): List<RuleEffect> {
         val ruleEngineContext = getRuleEngineContext(listOf(rule))
         val event =
             RuleEvent(
@@ -245,7 +256,7 @@ class ProgramRuleVariableTest {
                 programStage = PROGRAM_STAGE,
                 programStageName = PROGRAM_STAGE_NAME,
                 status = RULE_EVENT_STATUS,
-                eventDate = EVENT_DATE,
+                eventDate = eventDate,
                 createdDate = RuleInstant.now(),
                 createdAtClientDate = null,
                 dueDate = DUE_DATE,

--- a/src/commonTest/kotlin/org/hisp/dhis/rules/RuleEngineFunctionTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/rules/RuleEngineFunctionTest.kt
@@ -1,21 +1,15 @@
 package org.hisp.dhis.rules
 
-import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
-import kotlinx.datetime.minus
-import kotlinx.datetime.plus
-import kotlinx.datetime.toLocalDateTime
-import kotlin.time.Clock
+import kotlinx.datetime.*
 import org.hisp.dhis.rules.api.RuleEngine
 import org.hisp.dhis.rules.api.RuleEngineContext
 import org.hisp.dhis.rules.api.RuleSupplementaryData
 import org.hisp.dhis.rules.models.*
 import org.hisp.dhis.rules.utils.currentDate
-import kotlin.test.*
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 
 class RuleEngineFunctionTest {
@@ -336,8 +330,7 @@ class RuleEngineFunctionTest {
                 "test_program_stage",
                 "",
                 RuleEventStatus.ACTIVE,
-                RuleLocalDate.fromLocalDate(Instant.DISTANT_FUTURE.toLocalDateTime(TimeZone.currentSystemDefault()).date.plus(2,
-                    DateTimeUnit.DAY)),
+                RuleLocalDate.distantFuture(),
                 RuleInstant.now(),
                 null,
                 RuleLocalDate.currentDate(),
@@ -371,8 +364,7 @@ class RuleEngineFunctionTest {
                 "test_program_stage",
                 "",
                 RuleEventStatus.ACTIVE,
-                RuleLocalDate.fromLocalDate(Instant.DISTANT_FUTURE.toLocalDateTime(TimeZone.currentSystemDefault()).date.plus(2,
-                    DateTimeUnit.DAY)),
+                RuleLocalDate.distantFuture(),
                 RuleInstant.now(),
                 null,
                 RuleLocalDate.currentDate(),

--- a/src/jsMain/kotlin/org/hisp/dhis/rules/RuleEngineJs.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/rules/RuleEngineJs.kt
@@ -2,14 +2,11 @@ package org.hisp.dhis.rules
 
 import js.array.tupleOf
 import js.collections.JsMap
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import org.hisp.dhis.rules.api.DataItem
 import org.hisp.dhis.rules.api.RuleEngine
 import org.hisp.dhis.rules.api.RuleEngineContext
 import org.hisp.dhis.rules.api.RuleSupplementaryData
 import org.hisp.dhis.rules.models.*
-import kotlin.time.Instant
 
 
 @JsExport
@@ -85,7 +82,7 @@ class RuleEngineJs(verbose: Boolean = false) {
             programStage = event.programStage,
             programStageName = event.programStageName,
             status = event.status,
-            eventDate = event.eventDate ?: RuleLocalDate.fromLocalDate(Instant.DISTANT_FUTURE.toLocalDateTime(TimeZone.currentSystemDefault()).date),
+            eventDate = event.eventDate ?: RuleLocalDate.distantFuture(),
             createdDate = event.createdDate,
             createdAtClientDate = event.createdAtClientDate,
             dueDate = event.dueDate,


### PR DESCRIPTION
`null` value for `event_date` is allowed in JS API but it is mapped to a default value based on  `Instant.DISTANT_FUTURE`, because such an event is going to be evaluated as if it happened last compared with any other event.

This PR fixes the comparison to check if the `event_date` was equal to `DISTANT_FUTURE`.