### PR TITLE
perf: Reduce memory allocation for rules evaluation [DHIS2-21778]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
 }
 
-version = "3.7.1-SNAPSHOT"
+version = "3.7.2-SNAPSHOT"
 group = "org.hisp.dhis.rules"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
@@ -32,7 +32,7 @@ internal class DefaultRuleEngine : RuleEngine {
             target.event,
             valueMap,
             RuleConditionEvaluator.convertSupplementaryData(executionContext.ruleSupplementaryData),
-            filterRules(executionContext.rules, target),
+            filterRules(executionContext.rules, target).sorted(),
             AttributeType.DATA_ELEMENT,
         )
     }
@@ -54,7 +54,7 @@ internal class DefaultRuleEngine : RuleEngine {
             target.enrollment,
             valueMap,
             RuleConditionEvaluator.convertSupplementaryData(executionContext.ruleSupplementaryData),
-            filterRules(executionContext.rules),
+            filterRules(executionContext.rules).sorted(),
             AttributeType.TRACKED_ENTITY_ATTRIBUTE,
         )
     }

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
@@ -31,7 +31,7 @@ internal class DefaultRuleEngine : RuleEngine {
             TrackerObjectType.EVENT,
             target.event,
             valueMap,
-            executionContext.ruleSupplementaryData,
+            RuleConditionEvaluator.convertSupplementaryData(executionContext.ruleSupplementaryData),
             filterRules(executionContext.rules, target),
             AttributeType.DATA_ELEMENT,
         )
@@ -53,7 +53,7 @@ internal class DefaultRuleEngine : RuleEngine {
             TrackerObjectType.ENROLLMENT,
             target.enrollment,
             valueMap,
-            executionContext.ruleSupplementaryData,
+            RuleConditionEvaluator.convertSupplementaryData(executionContext.ruleSupplementaryData),
             filterRules(executionContext.rules),
             AttributeType.TRACKED_ENTITY_ATTRIBUTE,
         )

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/DefaultRuleEngine.kt
@@ -33,6 +33,7 @@ internal class DefaultRuleEngine : RuleEngine {
             valueMap,
             executionContext.ruleSupplementaryData,
             filterRules(executionContext.rules, target),
+            AttributeType.DATA_ELEMENT,
         )
     }
 
@@ -54,6 +55,7 @@ internal class DefaultRuleEngine : RuleEngine {
             valueMap,
             executionContext.ruleSupplementaryData,
             filterRules(executionContext.rules),
+            AttributeType.TRACKED_ENTITY_ATTRIBUTE,
         )
     }
 

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
@@ -19,11 +19,11 @@ internal class RuleConditionEvaluator {
         targetType: TrackerObjectType,
         targetUid: String,
         valueMap: Map<String, VariableValue>,
-        ruleSupplementaryData: RuleSupplementaryData,
+        supplementaryMap: Map<String, List<String>>,
         rules: List<Rule>,
         attributeType: AttributeType,
     ): List<RuleEffect> {
-        val ruleEvaluationResults = getRuleEvaluationResults(targetType, targetUid, valueMap, ruleSupplementaryData, rules, attributeType)
+        val ruleEvaluationResults = getRuleEvaluationResults(targetType, targetUid, valueMap, supplementaryMap, rules, attributeType)
         return ruleEvaluationResults
             .flatMap { result -> result.ruleEffects }
     }
@@ -32,7 +32,7 @@ internal class RuleConditionEvaluator {
         targetType: TrackerObjectType,
         targetUid: String,
         valueMap: Map<String, VariableValue>,
-        ruleSupplementaryData: RuleSupplementaryData,
+        supplementaryMap: Map<String, List<String>>,
         rules: List<Rule>,
         attributeType: AttributeType,
     ): List<RuleEffect> {
@@ -41,7 +41,7 @@ internal class RuleConditionEvaluator {
                 targetType,
                 targetUid,
                 valueMap,
-                ruleSupplementaryData,
+                supplementaryMap,
                 rules,
                 attributeType,
             )
@@ -54,7 +54,7 @@ internal class RuleConditionEvaluator {
         targetType: TrackerObjectType,
         targetUid: String,
         valueMap: Map<String, VariableValue>,
-        ruleSupplementaryData: RuleSupplementaryData,
+        supplementaryMap: Map<String, List<String>>,
         rules: List<Rule>,
         attributeType: AttributeType,
     ): List<RuleEvaluationResult> {
@@ -67,7 +67,7 @@ internal class RuleConditionEvaluator {
                 if (process(
                         rule.conditionExpression,
                         mutableValueMap,
-                        ruleSupplementaryData,
+                        supplementaryMap,
                     ).toBoolean()
                 ) {
                     for (action in rule.actions.filter { isAllowedAction(it, attributeType) }.sorted()) {
@@ -78,14 +78,14 @@ internal class RuleConditionEvaluator {
                                     unwrapVariableName(action.content()!!),
                                     VariableValue(
                                         ValueType.STRING,
-                                        process(action.dataExpression, mutableValueMap, ruleSupplementaryData),
+                                        process(action.dataExpression, mutableValueMap, supplementaryMap),
                                         listOf(),
                                         null,
                                     ),
                                     mutableValueMap,
                                 )
                             } else {
-                                ruleEffects.add(create(rule, action, mutableValueMap, ruleSupplementaryData))
+                                ruleEffects.add(create(rule, action, mutableValueMap, supplementaryMap))
                             }
                         } catch (e: Exception) {
                             addRuleErrorResult(rule, action, e, targetType, targetUid, ruleEvaluationResults)
@@ -150,14 +150,14 @@ internal class RuleConditionEvaluator {
     private fun process(
         expressionResult: Result<Expression?>,
         valueMap: Map<String, VariableValue>,
-        ruleSupplementaryData: RuleSupplementaryData,
+        supplementaryMap: Map<String, List<String>>,
     ): String? {
         val expression = expressionResult.getOrThrow() ?: return ""
         val build =
             ExpressionData(
                 valueMap,
                 emptyMap(),
-                convertSupplementaryData(ruleSupplementaryData),
+                supplementaryMap,
                 emptyMap(),
                 emptyMap(),
             )
@@ -168,16 +168,6 @@ internal class RuleConditionEvaluator {
                 )
             }, build),
         )?.toString()
-    }
-
-    private fun convertSupplementaryData(ruleSupplementaryData: RuleSupplementaryData): Map<String, List<String>> {
-        val supplementaryValues: MutableMap<String, List<String>> = HashMap()
-
-        supplementaryValues["USER_GROUPS"] = ruleSupplementaryData.userGroups
-        supplementaryValues["USER_ROLES"] = ruleSupplementaryData.userRoles
-        supplementaryValues.putAll(ruleSupplementaryData.orgUnitGroups)
-
-        return supplementaryValues
     }
 
     private fun convertInteger(result: Any?): Any? =
@@ -201,10 +191,10 @@ internal class RuleConditionEvaluator {
         rule: Rule,
         ruleAction: RuleAction,
         valueMap: MutableMap<String, VariableValue>,
-        ruleSupplementaryData: RuleSupplementaryData,
+        supplementaryMap: Map<String, List<String>>,
     ): RuleEffect {
         if (ruleAction.type == "ASSIGN") {
-            val data = processRuleAction(rule, ruleAction, valueMap, ruleSupplementaryData)
+            val data = processRuleAction(rule, ruleAction, valueMap, supplementaryMap)
             updateValueMap(ruleAction.field()!!, VariableValue(ValueType.STRING, data, listOf(), null), valueMap)
             return if (data.isNullOrEmpty()) {
                 RuleEffect(rule.uid, ruleAction, null)
@@ -218,7 +208,7 @@ internal class RuleConditionEvaluator {
                     rule,
                     ruleAction,
                     valueMap,
-                    ruleSupplementaryData,
+                    supplementaryMap,
                 )
             } else {
                 ""
@@ -234,12 +224,12 @@ internal class RuleConditionEvaluator {
         rule: Rule,
         ruleAction: RuleAction,
         valueMap: MutableMap<String, VariableValue>,
-        supplementaryData: RuleSupplementaryData,
+        supplementaryMap: Map<String, List<String>>,
     ): String? {
         val data = process(
             ruleAction.dataExpression,
             valueMap,
-            supplementaryData,
+            supplementaryMap,
         )
         log.fine(
             "Action " + ruleAction.type +
@@ -252,5 +242,13 @@ internal class RuleConditionEvaluator {
 
     companion object {
         private val log = createLogger("org.hisp.dhis.rules.engine.RuleConditionEvaluator")
+
+        fun convertSupplementaryData(ruleSupplementaryData: RuleSupplementaryData): Map<String, List<String>> {
+            val supplementaryValues: MutableMap<String, List<String>> = HashMap()
+            supplementaryValues["USER_GROUPS"] = ruleSupplementaryData.userGroups
+            supplementaryValues["USER_ROLES"] = ruleSupplementaryData.userRoles
+            supplementaryValues.putAll(ruleSupplementaryData.orgUnitGroups)
+            return supplementaryValues
+        }
     }
 }

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
@@ -1,7 +1,6 @@
 package org.hisp.dhis.rules.engine
 
 import org.hisp.dhis.lib.expression.Expression
-import org.hisp.dhis.lib.expression.ExpressionMode
 import org.hisp.dhis.lib.expression.spi.ExpressionData
 import org.hisp.dhis.lib.expression.spi.IllegalExpressionException
 import org.hisp.dhis.lib.expression.spi.ValueType
@@ -12,6 +11,7 @@ import org.hisp.dhis.rules.engine.RuleEvaluationResult.Companion.errorRule
 import org.hisp.dhis.rules.engine.RuleEvaluationResult.Companion.evaluatedResult
 import org.hisp.dhis.rules.engine.RuleEvaluationResult.Companion.notEvaluatedResult
 import org.hisp.dhis.rules.models.*
+import org.hisp.dhis.rules.utils.isAllowedAction
 import org.hisp.dhis.rules.utils.unwrapVariableName
 
 internal class RuleConditionEvaluator {
@@ -21,8 +21,9 @@ internal class RuleConditionEvaluator {
         valueMap: Map<String, VariableValue>,
         ruleSupplementaryData: RuleSupplementaryData,
         rules: List<Rule>,
+        attributeType: AttributeType,
     ): List<RuleEffect> {
-        val ruleEvaluationResults = getRuleEvaluationResults(targetType, targetUid, valueMap, ruleSupplementaryData, rules)
+        val ruleEvaluationResults = getRuleEvaluationResults(targetType, targetUid, valueMap, ruleSupplementaryData, rules, attributeType)
         return ruleEvaluationResults
             .flatMap { result -> result.ruleEffects }
     }
@@ -33,6 +34,7 @@ internal class RuleConditionEvaluator {
         valueMap: Map<String, VariableValue>,
         ruleSupplementaryData: RuleSupplementaryData,
         rules: List<Rule>,
+        attributeType: AttributeType,
     ): List<RuleEffect> {
         val ruleEvaluationResults =
             getRuleEvaluationResults(
@@ -41,6 +43,7 @@ internal class RuleConditionEvaluator {
                 valueMap,
                 ruleSupplementaryData,
                 rules,
+                attributeType,
             )
         return ruleEvaluationResults
             .filter { result -> !result.error }
@@ -53,6 +56,7 @@ internal class RuleConditionEvaluator {
         valueMap: Map<String, VariableValue>,
         ruleSupplementaryData: RuleSupplementaryData,
         rules: List<Rule>,
+        attributeType: AttributeType,
     ): List<RuleEvaluationResult> {
         val mutableValueMap = valueMap.toMutableMap()
         val ruleEvaluationResults: MutableList<RuleEvaluationResult> = ArrayList()
@@ -61,13 +65,12 @@ internal class RuleConditionEvaluator {
             try {
                 val ruleEffects: MutableList<RuleEffect> = ArrayList()
                 if (process(
-                        rule.condition,
+                        rule.conditionExpression,
                         mutableValueMap,
                         ruleSupplementaryData,
-                        ExpressionMode.RULE_ENGINE_CONDITION,
                     ).toBoolean()
                 ) {
-                    for (action in rule.actions.sorted()) {
+                    for (action in rule.actions.filter { isAllowedAction(it, attributeType) }.sorted()) {
                         try {
                             // Check if action is assigning value to calculated variable
                             if (isAssignToCalculatedValue(action)) {
@@ -75,7 +78,7 @@ internal class RuleConditionEvaluator {
                                     unwrapVariableName(action.content()!!),
                                     VariableValue(
                                         ValueType.STRING,
-                                        process(action.data, mutableValueMap, ruleSupplementaryData, ExpressionMode.RULE_ENGINE_ACTION),
+                                        process(action.dataExpression, mutableValueMap, ruleSupplementaryData),
                                         listOf(),
                                         null,
                                     ),
@@ -145,16 +148,11 @@ internal class RuleConditionEvaluator {
     }
 
     private fun process(
-        condition: String?,
+        expressionResult: Result<Expression?>,
         valueMap: Map<String, VariableValue>,
         ruleSupplementaryData: RuleSupplementaryData,
-        mode: ExpressionMode,
     ): String? {
-        if (condition.isNullOrEmpty()) {
-            return ""
-        }
-        val expression = Expression(condition, mode, false)
-
+        val expression = expressionResult.getOrThrow() ?: return ""
         val build =
             ExpressionData(
                 valueMap,
@@ -239,10 +237,9 @@ internal class RuleConditionEvaluator {
         supplementaryData: RuleSupplementaryData,
     ): String? {
         val data = process(
-            ruleAction.data,
+            ruleAction.dataExpression,
             valueMap,
             supplementaryData,
-            ExpressionMode.RULE_ENGINE_ACTION,
         )
         log.fine(
             "Action " + ruleAction.type +

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
@@ -11,14 +11,13 @@ import org.hisp.dhis.rules.engine.RuleEvaluationResult.Companion.errorRule
 import org.hisp.dhis.rules.engine.RuleEvaluationResult.Companion.evaluatedResult
 import org.hisp.dhis.rules.engine.RuleEvaluationResult.Companion.notEvaluatedResult
 import org.hisp.dhis.rules.models.*
-import org.hisp.dhis.rules.utils.isAllowedAction
 import org.hisp.dhis.rules.utils.unwrapVariableName
 
 internal class RuleConditionEvaluator {
     fun getEvaluatedAndErrorRuleEffects(
         targetType: TrackerObjectType,
         targetUid: String,
-        valueMap: Map<String, VariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
         supplementaryMap: Map<String, List<String>>,
         rules: List<Rule>,
         attributeType: AttributeType,
@@ -31,7 +30,7 @@ internal class RuleConditionEvaluator {
     fun getRuleEffects(
         targetType: TrackerObjectType,
         targetUid: String,
-        valueMap: Map<String, VariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
         supplementaryMap: Map<String, List<String>>,
         rules: List<Rule>,
         attributeType: AttributeType,
@@ -53,24 +52,23 @@ internal class RuleConditionEvaluator {
     fun getRuleEvaluationResults(
         targetType: TrackerObjectType,
         targetUid: String,
-        valueMap: Map<String, VariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
         supplementaryMap: Map<String, List<String>>,
         rules: List<Rule>,
         attributeType: AttributeType,
     ): List<RuleEvaluationResult> {
-        val mutableValueMap = valueMap.toMutableMap()
         val ruleEvaluationResults: MutableList<RuleEvaluationResult> = ArrayList()
-        for (rule in rules.sorted()) {
+        for (rule in rules) {
             log.fine("Evaluating programrule: " + rule.name)
             try {
                 val ruleEffects: MutableList<RuleEffect> = ArrayList()
                 if (process(
                         rule.conditionExpression,
-                        mutableValueMap,
+                        valueMap,
                         supplementaryMap,
                     ).toBoolean()
                 ) {
-                    for (action in rule.actions.filter { isAllowedAction(it, attributeType) }.sorted()) {
+                    for (action in if (attributeType == AttributeType.DATA_ELEMENT) rule.actionsForDataElement else rule.actionsForEnrollment) {
                         try {
                             // Check if action is assigning value to calculated variable
                             if (isAssignToCalculatedValue(action)) {
@@ -78,14 +76,14 @@ internal class RuleConditionEvaluator {
                                     unwrapVariableName(action.content()!!),
                                     VariableValue(
                                         ValueType.STRING,
-                                        process(action.dataExpression, mutableValueMap, supplementaryMap),
+                                        process(action.dataExpression, valueMap, supplementaryMap),
                                         listOf(),
                                         null,
                                     ),
-                                    mutableValueMap,
+                                    valueMap,
                                 )
                             } else {
-                                ruleEffects.add(create(rule, action, mutableValueMap, supplementaryMap))
+                                ruleEffects.add(create(rule, action, valueMap, supplementaryMap))
                             }
                         } catch (e: Exception) {
                             addRuleErrorResult(rule, action, e, targetType, targetUid, ruleEvaluationResults)

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleConditionEvaluator.kt
@@ -4,6 +4,8 @@ import org.hisp.dhis.lib.expression.Expression
 import org.hisp.dhis.lib.expression.ExpressionMode
 import org.hisp.dhis.lib.expression.spi.ExpressionData
 import org.hisp.dhis.lib.expression.spi.IllegalExpressionException
+import org.hisp.dhis.lib.expression.spi.ValueType
+import org.hisp.dhis.lib.expression.spi.VariableValue
 import org.hisp.dhis.rules.api.RuleSupplementaryData
 import org.hisp.dhis.rules.createLogger
 import org.hisp.dhis.rules.engine.RuleEvaluationResult.Companion.errorRule
@@ -16,7 +18,7 @@ internal class RuleConditionEvaluator {
     fun getEvaluatedAndErrorRuleEffects(
         targetType: TrackerObjectType,
         targetUid: String,
-        valueMap: Map<String, RuleVariableValue>,
+        valueMap: Map<String, VariableValue>,
         ruleSupplementaryData: RuleSupplementaryData,
         rules: List<Rule>,
     ): List<RuleEffect> {
@@ -28,7 +30,7 @@ internal class RuleConditionEvaluator {
     fun getRuleEffects(
         targetType: TrackerObjectType,
         targetUid: String,
-        valueMap: Map<String, RuleVariableValue>,
+        valueMap: Map<String, VariableValue>,
         ruleSupplementaryData: RuleSupplementaryData,
         rules: List<Rule>,
     ): List<RuleEffect> {
@@ -48,7 +50,7 @@ internal class RuleConditionEvaluator {
     fun getRuleEvaluationResults(
         targetType: TrackerObjectType,
         targetUid: String,
-        valueMap: Map<String, RuleVariableValue>,
+        valueMap: Map<String, VariableValue>,
         ruleSupplementaryData: RuleSupplementaryData,
         rules: List<Rule>,
     ): List<RuleEvaluationResult> {
@@ -71,8 +73,8 @@ internal class RuleConditionEvaluator {
                             if (isAssignToCalculatedValue(action)) {
                                 updateValueMap(
                                     unwrapVariableName(action.content()!!),
-                                    RuleVariableValue(
-                                        RuleValueType.TEXT,
+                                    VariableValue(
+                                        ValueType.STRING,
                                         process(action.data, mutableValueMap, ruleSupplementaryData, ExpressionMode.RULE_ENGINE_ACTION),
                                         listOf(),
                                         null,
@@ -144,7 +146,7 @@ internal class RuleConditionEvaluator {
 
     private fun process(
         condition: String?,
-        valueMap: Map<String, RuleVariableValue>,
+        valueMap: Map<String, VariableValue>,
         ruleSupplementaryData: RuleSupplementaryData,
         mode: ExpressionMode,
     ): String? {
@@ -155,7 +157,7 @@ internal class RuleConditionEvaluator {
 
         val build =
             ExpressionData(
-                valueMap.mapValues { (_,v) -> v.toVariableValue() },
+                valueMap,
                 emptyMap(),
                 convertSupplementaryData(ruleSupplementaryData),
                 emptyMap(),
@@ -191,8 +193,8 @@ internal class RuleConditionEvaluator {
 
     private fun updateValueMap(
         variable: String,
-        value: RuleVariableValue,
-        valueMap: MutableMap<String, RuleVariableValue>,
+        value: VariableValue,
+        valueMap: MutableMap<String, VariableValue>,
     ) {
         valueMap[variable] = value
     }
@@ -200,12 +202,12 @@ internal class RuleConditionEvaluator {
     private fun create(
         rule: Rule,
         ruleAction: RuleAction,
-        valueMap: MutableMap<String, RuleVariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
         ruleSupplementaryData: RuleSupplementaryData,
     ): RuleEffect {
         if (ruleAction.type == "ASSIGN") {
             val data = processRuleAction(rule, ruleAction, valueMap, ruleSupplementaryData)
-            updateValueMap(ruleAction.field()!!, RuleVariableValue(RuleValueType.TEXT, data, listOf(), null), valueMap)
+            updateValueMap(ruleAction.field()!!, VariableValue(ValueType.STRING, data, listOf(), null), valueMap)
             return if (data.isNullOrEmpty()) {
                 RuleEffect(rule.uid, ruleAction, null)
             } else {
@@ -233,7 +235,7 @@ internal class RuleConditionEvaluator {
     private fun processRuleAction(
         rule: Rule,
         ruleAction: RuleAction,
-        valueMap: MutableMap<String, RuleVariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
         supplementaryData: RuleSupplementaryData,
     ): String? {
         val data = process(

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleEngineMultipleExecution.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleEngineMultipleExecution.kt
@@ -10,18 +10,19 @@ internal class RuleEngineMultipleExecution {
         ruleVariableValueMap: RuleVariableValueMap,
         ruleSupplementaryData: RuleSupplementaryData,
     ): List<RuleEffects> {
+        val supplementaryMap = RuleConditionEvaluator.convertSupplementaryData(ruleSupplementaryData)
+        val evaluator = RuleConditionEvaluator()
         val ruleEffects: MutableList<RuleEffects> = ArrayList()
         for ((enrollment, valueMap) in ruleVariableValueMap.enrollmentMap) {
             val enrollmentRuleEffects =
-                RuleConditionEvaluator()
-                    .getEvaluatedAndErrorRuleEffects(
-                        TrackerObjectType.ENROLLMENT,
-                        enrollment.enrollment,
-                        valueMap,
-                        ruleSupplementaryData,
-                        filterRules(rules),
-                        AttributeType.TRACKED_ENTITY_ATTRIBUTE,
-                    )
+                evaluator.getEvaluatedAndErrorRuleEffects(
+                    TrackerObjectType.ENROLLMENT,
+                    enrollment.enrollment,
+                    valueMap,
+                    supplementaryMap,
+                    filterRules(rules),
+                    AttributeType.TRACKED_ENTITY_ATTRIBUTE,
+                )
             ruleEffects.add(
                 RuleEffects(
                     TrackerObjectType.ENROLLMENT,
@@ -35,11 +36,11 @@ internal class RuleEngineMultipleExecution {
                 RuleEffects(
                     TrackerObjectType.EVENT,
                     event.event,
-                    RuleConditionEvaluator().getEvaluatedAndErrorRuleEffects(
+                    evaluator.getEvaluatedAndErrorRuleEffects(
                         TrackerObjectType.EVENT,
                         event.event,
                         valueMap,
-                        ruleSupplementaryData,
+                        supplementaryMap,
                         filterRules(rules, event),
                         AttributeType.DATA_ELEMENT,
                     ),

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleEngineMultipleExecution.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleEngineMultipleExecution.kt
@@ -20,6 +20,7 @@ internal class RuleEngineMultipleExecution {
                         valueMap,
                         ruleSupplementaryData,
                         filterRules(rules),
+                        AttributeType.TRACKED_ENTITY_ATTRIBUTE,
                     )
             ruleEffects.add(
                 RuleEffects(
@@ -40,6 +41,7 @@ internal class RuleEngineMultipleExecution {
                         valueMap,
                         ruleSupplementaryData,
                         filterRules(rules, event),
+                        AttributeType.DATA_ELEMENT,
                     ),
                 ),
             )

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleEngineMultipleExecution.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleEngineMultipleExecution.kt
@@ -13,6 +13,11 @@ internal class RuleEngineMultipleExecution {
         val supplementaryMap = RuleConditionEvaluator.convertSupplementaryData(ruleSupplementaryData)
         val evaluator = RuleConditionEvaluator()
         val ruleEffects: MutableList<RuleEffects> = ArrayList()
+        val enrollmentRules: List<Rule> = filterRules(rules).sorted()
+        val rulesByStage: Map<String, List<Rule>> = rules
+            .filter { !it.programStage.isNullOrEmpty() }
+            .groupBy { it.programStage!! }
+            .mapValues { (_, stageRules) -> (enrollmentRules + stageRules).sorted() }
         for ((enrollment, valueMap) in ruleVariableValueMap.enrollmentMap) {
             val enrollmentRuleEffects =
                 evaluator.getEvaluatedAndErrorRuleEffects(
@@ -20,7 +25,7 @@ internal class RuleEngineMultipleExecution {
                     enrollment.enrollment,
                     valueMap,
                     supplementaryMap,
-                    filterRules(rules),
+                    enrollmentRules,
                     AttributeType.TRACKED_ENTITY_ATTRIBUTE,
                 )
             ruleEffects.add(
@@ -32,6 +37,7 @@ internal class RuleEngineMultipleExecution {
             )
         }
         for ((event, valueMap) in ruleVariableValueMap.eventMap) {
+            val eventRules = rulesByStage[event.programStage] ?: enrollmentRules
             ruleEffects.add(
                 RuleEffects(
                     TrackerObjectType.EVENT,
@@ -41,7 +47,7 @@ internal class RuleEngineMultipleExecution {
                         event.event,
                         valueMap,
                         supplementaryMap,
-                        filterRules(rules, event),
+                        eventRules,
                         AttributeType.DATA_ELEMENT,
                     ),
                 ),

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMap.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMap.kt
@@ -1,9 +1,10 @@
 package org.hisp.dhis.rules.engine
 
+import org.hisp.dhis.lib.expression.spi.VariableValue
 import org.hisp.dhis.rules.models.RuleEnrollment
 import org.hisp.dhis.rules.models.RuleEvent
 
 internal data class RuleVariableValueMap(
-    val enrollmentMap: Map<RuleEnrollment, Map<String, RuleVariableValue>>,
-    val eventMap: Map<RuleEvent, Map<String, RuleVariableValue>>,
+    val enrollmentMap: Map<RuleEnrollment, Map<String, VariableValue>>,
+    val eventMap: Map<RuleEvent, Map<String, VariableValue>>,
 )

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMap.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMap.kt
@@ -5,6 +5,6 @@ import org.hisp.dhis.rules.models.RuleEnrollment
 import org.hisp.dhis.rules.models.RuleEvent
 
 internal data class RuleVariableValueMap(
-    val enrollmentMap: Map<RuleEnrollment, Map<String, VariableValue>>,
-    val eventMap: Map<RuleEvent, Map<String, VariableValue>>,
+    val enrollmentMap: Map<RuleEnrollment, MutableMap<String, VariableValue>>,
+    val eventMap: Map<RuleEvent, MutableMap<String, VariableValue>>,
 )

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
@@ -4,7 +4,7 @@ import kotlinx.datetime.LocalDate
 import org.hisp.dhis.rules.models.*
 import org.hisp.dhis.rules.utils.RuleEngineUtils
 import org.hisp.dhis.rules.utils.currentDate
-import org.hisp.dhis.rules.utils.orderEvents
+
 
 
 internal class RuleVariableValueMapBuilder {
@@ -70,7 +70,7 @@ internal class RuleVariableValueMapBuilder {
 
     private fun buildAllEventValues(ruleEvents: Set<RuleEvent>): Map<String, List<RuleDataValueHistory>> {
         val allEventsValues: MutableMap<String, MutableList<RuleDataValueHistory>> = HashMap()
-        val events: List<RuleEvent> = orderEvents(ruleEvents).reversed()
+        val events: List<RuleEvent> = ruleEvents.sortedDescending()
 
         // aggregating values by data element uid
         for (i in events.indices) {

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
@@ -16,7 +16,7 @@ internal class RuleVariableValueMapBuilder {
         ruleEvents: Set<RuleEvent>,
         ruleEnrollment: RuleEnrollment? = null,
         ruleEvent: RuleEvent? = null,
-    ): Map<String, VariableValue> {
+    ): MutableMap<String, VariableValue> {
         val allEvents =
             ruleEvent?.let {
                 val set = HashSet(ruleEvents)
@@ -25,7 +25,7 @@ internal class RuleVariableValueMapBuilder {
             } ?: ruleEvents
         val allEventValues = buildAllEventValues(allEvents)
         val currentEnrollmentValues = ruleEnrollment?.let { buildCurrentEnrollmentValues(it) }.orEmpty()
-        return build(allConstantValues, ruleVariables, allEvents, ruleEnrollment, ruleEvent, allEventValues, currentEnrollmentValues)
+        return build(allConstantValues, ruleVariables, allEvents, ruleEnrollment, ruleEvent, allEventValues, currentEnrollmentValues, currentDate())
     }
 
     fun multipleBuild(
@@ -36,16 +36,17 @@ internal class RuleVariableValueMapBuilder {
     ): RuleVariableValueMap {
         val allEventValues = buildAllEventValues(ruleEvents)
         val currentEnrollmentValues = ruleEnrollment?.let { buildCurrentEnrollmentValues(it) }.orEmpty()
+        val currentDate = currentDate()
         val enrollmentMap =
             ruleEnrollment
                 ?.let { enrollment ->
-                    mapOf(Pair(enrollment, build(allConstantValues, ruleVariables, ruleEvents, enrollment, null, allEventValues, currentEnrollmentValues)))
+                    mapOf(Pair(enrollment, build(allConstantValues, ruleVariables, ruleEvents, enrollment, null, allEventValues, currentEnrollmentValues, currentDate)))
                 }.orEmpty()
         return RuleVariableValueMap(
             enrollmentMap,
             ruleEvents.associateBy({
                 it
-            }, { event -> build(allConstantValues, ruleVariables, ruleEvents, ruleEnrollment, event, allEventValues, currentEnrollmentValues) }),
+            }, { event -> build(allConstantValues, ruleVariables, ruleEvents, ruleEnrollment, event, allEventValues, currentEnrollmentValues, currentDate) }),
         )
     }
 
@@ -57,9 +58,10 @@ internal class RuleVariableValueMapBuilder {
         ruleEvent: RuleEvent?,
         allEventValues: Map<String, List<RuleDataValueHistory>>,
         currentEnrollmentValues: Map<String, RuleAttributeValue>,
-    ): Map<String, VariableValue> {
+        currentDate: LocalDate,
+    ): MutableMap<String, VariableValue> {
         val valueMap = HashMap<String, VariableValue>()
-        fillEnvironmentVariables(allEvents, ruleEnrollment, ruleEvent, valueMap)
+        fillEnvironmentVariables(allEvents, ruleEnrollment, ruleEvent, currentDate, valueMap)
         fillRuleVariableValues(ruleVariables, ruleEvent, allEventValues, currentEnrollmentValues, valueMap)
         fillConstantsValues(allConstantValues, valueMap)
         return valueMap
@@ -91,7 +93,7 @@ internal class RuleVariableValueMapBuilder {
                 )
             }
         }
-        return allEventsValues.toMap()
+        return allEventsValues
     }
 
     private fun fillConstantsValues(
@@ -107,9 +109,9 @@ internal class RuleVariableValueMapBuilder {
         ruleEvents: Set<RuleEvent>,
         ruleEnrollment: RuleEnrollment?,
         ruleEvent: RuleEvent?,
+        currentDate: LocalDate,
         valueMap: MutableMap<String, VariableValue>,
     ) {
-        val currentDate = currentDate()
         fillEnvironmentVariables(ruleEvents, currentDate, valueMap)
         ruleEnrollment?.let { fillEnrollmentEnvironmentVariables(it, currentDate, valueMap) }
         ruleEvent?.let { fillEventEnvironmentVariables(ruleEvents, it, currentDate, valueMap) }
@@ -120,19 +122,21 @@ internal class RuleVariableValueMapBuilder {
         currentDate: LocalDate,
         valueMap: MutableMap<String, VariableValue>,
     ) {
+        val currentDateStr = currentDate.toString()
+        val eventCountStr = ruleEvents.size.toString()
         valueMap[RuleEngineUtils.ENV_VAR_CURRENT_DATE] =
             VariableValue(
                 ValueType.DATE,
-                currentDate.toString(),
-                listOf(currentDate.toString()),
-                currentDate.toString(),
+                currentDateStr,
+                listOf(currentDateStr),
+                currentDateStr,
             )
         valueMap[RuleEngineUtils.ENV_VAR_EVENT_COUNT] =
             VariableValue(
                 ValueType.NUMBER,
-                ruleEvents.size.toString(),
-                listOf(ruleEvents.size.toString()),
-                currentDate.toString(),
+                eventCountStr,
+                listOf(eventCountStr),
+                currentDateStr,
             )
         val environment = TriggerEnvironment.SERVER.clientName
         valueMap[RuleEngineUtils.ENV_VAR_ENVIRONMENT] =
@@ -140,7 +144,7 @@ internal class RuleVariableValueMapBuilder {
                 ValueType.STRING,
                 environment,
                 listOf(environment),
-                currentDate.toString(),
+                currentDateStr,
             )
     }
 
@@ -150,6 +154,7 @@ internal class RuleVariableValueMapBuilder {
         currentDate: LocalDate,
         valueMap: MutableMap<String, VariableValue>,
     ) {
+        val currentDateStr = currentDate.toString()
         val eventDate =
             if (ruleEvent.eventDate < RuleLocalDate.distantFuture())
                 ruleEvent.eventDate.toString()
@@ -159,36 +164,39 @@ internal class RuleVariableValueMapBuilder {
                 ValueType.DATE,
                 eventDate,
                 eventDate?.let { listOf(it) } ?: emptyList(),
-                currentDate.toString(),
+                currentDateStr,
             )
+        val dueDate = ruleEvent.dueDate?.toString()
         valueMap[RuleEngineUtils.ENV_VAR_DUE_DATE] =
             VariableValue(
                 ValueType.DATE,
-                ruleEvent.dueDate?.toString(),
-                ruleEvent.dueDate?.let { listOf(it.toString()) } ?: emptyList(),
-                currentDate.toString(),
+                dueDate,
+                dueDate?.let { listOf(it) } ?: emptyList(),
+                currentDateStr,
             )
+        val completedDate = ruleEvent.completedDate?.toString()
         valueMap[RuleEngineUtils.ENV_VAR_COMPLETED_DATE] =
             VariableValue(
                 ValueType.DATE,
-                ruleEvent.completedDate?.toString(),
-                ruleEvent.completedDate?.let { listOf(it.toString()) } ?: emptyList(),
-                currentDate.toString(),
+                completedDate,
+                completedDate?.let { listOf(it) } ?: emptyList(),
+                currentDateStr,
             )
-        val eventCount = ruleEvents.size.toString()
+        val eventCountStr = ruleEvents.size.toString()
         valueMap[RuleEngineUtils.ENV_VAR_EVENT_COUNT] =
             VariableValue(
                 ValueType.NUMBER,
-                eventCount,
-                listOf(eventCount),
-                currentDate.toString(),
+                eventCountStr,
+                listOf(eventCountStr),
+                currentDateStr,
             )
+        val eventDateStr = ruleEvent.eventDate.toString()
         valueMap[RuleEngineUtils.ENV_VAR_EVENT_ID] =
             VariableValue(
                 ValueType.STRING,
                 ruleEvent.event,
                 listOf(ruleEvent.event),
-                ruleEvent.eventDate.toString(),
+                eventDateStr,
             )
         val status = ruleEvent.status.toString()
         valueMap[RuleEngineUtils.ENV_VAR_EVENT_STATUS] =
@@ -196,7 +204,7 @@ internal class RuleVariableValueMapBuilder {
                 ValueType.STRING,
                 status,
                 listOf(status),
-                currentDate.toString(),
+                currentDateStr,
             )
         valueMap[RuleEngineUtils.ENV_VAR_OU] = VariableValue(ValueType.STRING, ruleEvent.organisationUnit, listOf(), null)
         valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_STAGE_ID] = VariableValue(ValueType.STRING, ruleEvent.programStage, listOf(), null)
@@ -209,42 +217,43 @@ internal class RuleVariableValueMapBuilder {
         currentDate: LocalDate,
         valueMap: MutableMap<String, VariableValue>,
     ) {
+        val currentDateStr = currentDate.toString()
+        val enrollmentDateStr = ruleEnrollment.enrollmentDate.toString()
         valueMap[RuleEngineUtils.ENV_VAR_ENROLLMENT_ID] =
             VariableValue(
                 ValueType.STRING,
                 ruleEnrollment.enrollment,
                 listOf(ruleEnrollment.enrollment),
-                ruleEnrollment.enrollmentDate.toString(),
+                enrollmentDateStr,
             )
         valueMap[RuleEngineUtils.ENV_VAR_ENROLLMENT_COUNT] =
             VariableValue(
                 ValueType.NUMBER,
                 "1",
                 listOf("1"),
-                currentDate.toString(),
+                currentDateStr,
             )
         valueMap[RuleEngineUtils.ENV_VAR_TEI_COUNT] =
             VariableValue(
                 ValueType.NUMBER,
                 "1",
                 listOf("1"),
-                currentDate.toString(),
+                currentDateStr,
             )
-        val enrollmentDate = ruleEnrollment.enrollmentDate
         valueMap[RuleEngineUtils.ENV_VAR_ENROLLMENT_DATE] =
             VariableValue(
                 ValueType.DATE,
-                enrollmentDate.toString(),
-                listOf(enrollmentDate.toString()),
-                currentDate.toString(),
+                enrollmentDateStr,
+                listOf(enrollmentDateStr),
+                currentDateStr,
             )
-        val incidentDate = ruleEnrollment.incidentDate
+        val incidentDateStr = ruleEnrollment.incidentDate.toString()
         valueMap[RuleEngineUtils.ENV_VAR_INCIDENT_DATE] =
             VariableValue(
                 ValueType.DATE,
-                incidentDate.toString(),
-                listOf(incidentDate.toString()),
-                currentDate.toString(),
+                incidentDateStr,
+                listOf(incidentDateStr),
+                currentDateStr,
             )
         val status = ruleEnrollment.status.toString()
         valueMap[RuleEngineUtils.ENV_VAR_ENROLLMENT_STATUS] =
@@ -252,7 +261,7 @@ internal class RuleVariableValueMapBuilder {
                 ValueType.STRING,
                 status,
                 listOf(status),
-                currentDate.toString(),
+                currentDateStr,
             )
         valueMap[RuleEngineUtils.ENV_VAR_OU] = VariableValue(ValueType.STRING, ruleEnrollment.organisationUnit, listOf(), null)
         valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_NAME] = VariableValue(ValueType.STRING, ruleEnrollment.programName, listOf(), null)

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
@@ -1,6 +1,8 @@
 package org.hisp.dhis.rules.engine
 
 import kotlinx.datetime.LocalDate
+import org.hisp.dhis.lib.expression.spi.ValueType
+import org.hisp.dhis.lib.expression.spi.VariableValue
 import org.hisp.dhis.rules.models.*
 import org.hisp.dhis.rules.utils.RuleEngineUtils
 import org.hisp.dhis.rules.utils.currentDate
@@ -14,7 +16,7 @@ internal class RuleVariableValueMapBuilder {
         ruleEvents: Set<RuleEvent>,
         ruleEnrollment: RuleEnrollment? = null,
         ruleEvent: RuleEvent? = null,
-    ): Map<String, RuleVariableValue> {
+    ): Map<String, VariableValue> {
         val allEvents =
             ruleEvent?.let {
                 val set = HashSet(ruleEvents)
@@ -55,8 +57,8 @@ internal class RuleVariableValueMapBuilder {
         ruleEvent: RuleEvent?,
         allEventValues: Map<String, List<RuleDataValueHistory>>,
         currentEnrollmentValues: Map<String, RuleAttributeValue>,
-    ): Map<String, RuleVariableValue> {
-        val valueMap = HashMap<String, RuleVariableValue>()
+    ): Map<String, VariableValue> {
+        val valueMap = HashMap<String, VariableValue>()
         fillEnvironmentVariables(allEvents, ruleEnrollment, ruleEvent, valueMap)
         fillRuleVariableValues(ruleVariables, ruleEvent, allEventValues, currentEnrollmentValues, valueMap)
         fillConstantsValues(allConstantValues, valueMap)
@@ -94,10 +96,10 @@ internal class RuleVariableValueMapBuilder {
 
     private fun fillConstantsValues(
         allConstantValues: Map<String, String>,
-        valueMap: MutableMap<String, RuleVariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
     ) {
         allConstantValues.forEach { (key, value) ->
-            valueMap[key] = RuleVariableValue(RuleValueType.NUMERIC, value)
+            valueMap[key] = VariableValue(ValueType.NUMBER, value, listOf(), null)
         }
     }
 
@@ -105,7 +107,7 @@ internal class RuleVariableValueMapBuilder {
         ruleEvents: Set<RuleEvent>,
         ruleEnrollment: RuleEnrollment?,
         ruleEvent: RuleEvent?,
-        valueMap: MutableMap<String, RuleVariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
     ) {
         val currentDate = currentDate()
         fillEnvironmentVariables(ruleEvents, currentDate, valueMap)
@@ -116,26 +118,26 @@ internal class RuleVariableValueMapBuilder {
     private fun fillEnvironmentVariables(
         ruleEvents: Set<RuleEvent>,
         currentDate: LocalDate,
-        valueMap: MutableMap<String, RuleVariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
     ) {
         valueMap[RuleEngineUtils.ENV_VAR_CURRENT_DATE] =
-            RuleVariableValue(
-                RuleValueType.DATE,
+            VariableValue(
+                ValueType.DATE,
                 currentDate.toString(),
                 listOf(currentDate.toString()),
                 currentDate.toString(),
             )
         valueMap[RuleEngineUtils.ENV_VAR_EVENT_COUNT] =
-            RuleVariableValue(
-                RuleValueType.NUMERIC,
+            VariableValue(
+                ValueType.NUMBER,
                 ruleEvents.size.toString(),
                 listOf(ruleEvents.size.toString()),
                 currentDate.toString(),
             )
         val environment = TriggerEnvironment.SERVER.clientName
         valueMap[RuleEngineUtils.ENV_VAR_ENVIRONMENT] =
-            RuleVariableValue(
-                RuleValueType.TEXT,
+            VariableValue(
+                ValueType.STRING,
                 environment,
                 listOf(environment),
                 currentDate.toString(),
@@ -146,115 +148,115 @@ internal class RuleVariableValueMapBuilder {
         ruleEvents: Set<RuleEvent>,
         ruleEvent: RuleEvent,
         currentDate: LocalDate,
-        valueMap: MutableMap<String, RuleVariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
     ) {
         val eventDate =
             if (ruleEvent.eventDate < RuleLocalDate.distantFuture())
                 ruleEvent.eventDate.toString()
             else null
         valueMap[RuleEngineUtils.ENV_VAR_EVENT_DATE] =
-            RuleVariableValue(
-                RuleValueType.DATE,
+            VariableValue(
+                ValueType.DATE,
                 eventDate,
                 eventDate?.let { listOf(it) } ?: emptyList(),
                 currentDate.toString(),
             )
         valueMap[RuleEngineUtils.ENV_VAR_DUE_DATE] =
-            RuleVariableValue(
-                RuleValueType.DATE,
+            VariableValue(
+                ValueType.DATE,
                 ruleEvent.dueDate?.toString(),
                 ruleEvent.dueDate?.let { listOf(it.toString()) } ?: emptyList(),
                 currentDate.toString(),
             )
         valueMap[RuleEngineUtils.ENV_VAR_COMPLETED_DATE] =
-            RuleVariableValue(
-                RuleValueType.DATE,
+            VariableValue(
+                ValueType.DATE,
                 ruleEvent.completedDate?.toString(),
                 ruleEvent.completedDate?.let { listOf(it.toString()) } ?: emptyList(),
                 currentDate.toString(),
             )
         val eventCount = ruleEvents.size.toString()
         valueMap[RuleEngineUtils.ENV_VAR_EVENT_COUNT] =
-            RuleVariableValue(
-                RuleValueType.NUMERIC,
+            VariableValue(
+                ValueType.NUMBER,
                 eventCount,
                 listOf(eventCount),
                 currentDate.toString(),
             )
         valueMap[RuleEngineUtils.ENV_VAR_EVENT_ID] =
-            RuleVariableValue(
-                RuleValueType.TEXT,
+            VariableValue(
+                ValueType.STRING,
                 ruleEvent.event,
                 listOf(ruleEvent.event),
                 ruleEvent.eventDate.toString(),
             )
         val status = ruleEvent.status.toString()
         valueMap[RuleEngineUtils.ENV_VAR_EVENT_STATUS] =
-            RuleVariableValue(
-                RuleValueType.TEXT,
+            VariableValue(
+                ValueType.STRING,
                 status,
                 listOf(status),
                 currentDate.toString(),
             )
-        valueMap[RuleEngineUtils.ENV_VAR_OU] = RuleVariableValue(RuleValueType.TEXT, ruleEvent.organisationUnit)
-        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_STAGE_ID] = RuleVariableValue(RuleValueType.TEXT, ruleEvent.programStage)
-        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_STAGE_NAME] = RuleVariableValue(RuleValueType.TEXT, ruleEvent.programStageName)
-        valueMap[RuleEngineUtils.ENV_VAR_OU_CODE] = RuleVariableValue(RuleValueType.TEXT, ruleEvent.organisationUnitCode)
+        valueMap[RuleEngineUtils.ENV_VAR_OU] = VariableValue(ValueType.STRING, ruleEvent.organisationUnit, listOf(), null)
+        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_STAGE_ID] = VariableValue(ValueType.STRING, ruleEvent.programStage, listOf(), null)
+        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_STAGE_NAME] = VariableValue(ValueType.STRING, ruleEvent.programStageName, listOf(), null)
+        valueMap[RuleEngineUtils.ENV_VAR_OU_CODE] = VariableValue(ValueType.STRING, ruleEvent.organisationUnitCode, listOf(), null)
     }
 
     private fun fillEnrollmentEnvironmentVariables(
         ruleEnrollment: RuleEnrollment,
         currentDate: LocalDate,
-        valueMap: MutableMap<String, RuleVariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
     ) {
         valueMap[RuleEngineUtils.ENV_VAR_ENROLLMENT_ID] =
-            RuleVariableValue(
-                RuleValueType.TEXT,
+            VariableValue(
+                ValueType.STRING,
                 ruleEnrollment.enrollment,
                 listOf(ruleEnrollment.enrollment),
                 ruleEnrollment.enrollmentDate.toString(),
             )
         valueMap[RuleEngineUtils.ENV_VAR_ENROLLMENT_COUNT] =
-            RuleVariableValue(
-                RuleValueType.NUMERIC,
+            VariableValue(
+                ValueType.NUMBER,
                 "1",
                 listOf("1"),
                 currentDate.toString(),
             )
         valueMap[RuleEngineUtils.ENV_VAR_TEI_COUNT] =
-            RuleVariableValue(
-                RuleValueType.NUMERIC,
+            VariableValue(
+                ValueType.NUMBER,
                 "1",
                 listOf("1"),
                 currentDate.toString(),
             )
         val enrollmentDate = ruleEnrollment.enrollmentDate
         valueMap[RuleEngineUtils.ENV_VAR_ENROLLMENT_DATE] =
-            RuleVariableValue(
-                RuleValueType.DATE,
+            VariableValue(
+                ValueType.DATE,
                 enrollmentDate.toString(),
                 listOf(enrollmentDate.toString()),
                 currentDate.toString(),
             )
         val incidentDate = ruleEnrollment.incidentDate
         valueMap[RuleEngineUtils.ENV_VAR_INCIDENT_DATE] =
-            RuleVariableValue(
-                RuleValueType.DATE,
+            VariableValue(
+                ValueType.DATE,
                 incidentDate.toString(),
                 listOf(incidentDate.toString()),
                 currentDate.toString(),
             )
         val status = ruleEnrollment.status.toString()
         valueMap[RuleEngineUtils.ENV_VAR_ENROLLMENT_STATUS] =
-            RuleVariableValue(
-                RuleValueType.TEXT,
+            VariableValue(
+                ValueType.STRING,
                 status,
                 listOf(status),
                 currentDate.toString(),
             )
-        valueMap[RuleEngineUtils.ENV_VAR_OU] = RuleVariableValue(RuleValueType.TEXT, ruleEnrollment.organisationUnit)
-        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_NAME] = RuleVariableValue(RuleValueType.TEXT, ruleEnrollment.programName)
-        valueMap[RuleEngineUtils.ENV_VAR_OU_CODE] = RuleVariableValue(RuleValueType.TEXT, ruleEnrollment.organisationUnitCode)
+        valueMap[RuleEngineUtils.ENV_VAR_OU] = VariableValue(ValueType.STRING, ruleEnrollment.organisationUnit, listOf(), null)
+        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_NAME] = VariableValue(ValueType.STRING, ruleEnrollment.programName, listOf(), null)
+        valueMap[RuleEngineUtils.ENV_VAR_OU_CODE] = VariableValue(ValueType.STRING, ruleEnrollment.organisationUnitCode, listOf(), null)
     }
 
     private fun fillRuleVariableValues(
@@ -262,10 +264,10 @@ internal class RuleVariableValueMapBuilder {
         ruleEvent: RuleEvent?,
         allEventValues: Map<String, List<RuleDataValueHistory>>,
         currentEnrollmentValues: Map<String, RuleAttributeValue>,
-        valueMap: MutableMap<String, RuleVariableValue>,
+        valueMap: MutableMap<String, VariableValue>,
     ) {
         ruleVariables.forEach { variable ->
-            valueMap[variable.name] = variable.createValues(ruleEvent, allEventValues, currentEnrollmentValues)
+            valueMap[variable.name] = variable.createValues(ruleEvent, allEventValues, currentEnrollmentValues).toVariableValue()
         }
     }
 }

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
@@ -21,9 +21,9 @@ internal class RuleVariableValueMapBuilder {
                 set.add(it)
                 set.toSet()
             } ?: ruleEvents
-        return buildEnvironmentVariables(allEvents, ruleEnrollment, ruleEvent) +
-            buildRuleVariableValues(ruleVariables, allEvents, ruleEnrollment, ruleEvent) +
-            buildConstantsValues(allConstantValues)
+        val allEventValues = buildAllEventValues(allEvents)
+        val currentEnrollmentValues = ruleEnrollment?.let { buildCurrentEnrollmentValues(it) }.orEmpty()
+        return build(allConstantValues, ruleVariables, allEvents, ruleEnrollment, ruleEvent, allEventValues, currentEnrollmentValues)
     }
 
     fun multipleBuild(
@@ -32,18 +32,33 @@ internal class RuleVariableValueMapBuilder {
         ruleEvents: Set<RuleEvent>,
         ruleEnrollment: RuleEnrollment? = null,
     ): RuleVariableValueMap {
+        val allEventValues = buildAllEventValues(ruleEvents)
+        val currentEnrollmentValues = ruleEnrollment?.let { buildCurrentEnrollmentValues(it) }.orEmpty()
         val enrollmentMap =
             ruleEnrollment
                 ?.let { enrollment ->
-                    mapOf(Pair(enrollment, build(allConstantValues, ruleVariables, ruleEvents, ruleEnrollment)))
+                    mapOf(Pair(enrollment, build(allConstantValues, ruleVariables, ruleEvents, enrollment, null, allEventValues, currentEnrollmentValues)))
                 }.orEmpty()
         return RuleVariableValueMap(
             enrollmentMap,
             ruleEvents.associateBy({
                 it
-            }, { build(allConstantValues, ruleVariables, ruleEvents, ruleEnrollment, it) }),
+            }, { event -> build(allConstantValues, ruleVariables, ruleEvents, ruleEnrollment, event, allEventValues, currentEnrollmentValues) }),
         )
     }
+
+    private fun build(
+        allConstantValues: Map<String, String>,
+        ruleVariables: List<RuleVariable>,
+        allEvents: Set<RuleEvent>,
+        ruleEnrollment: RuleEnrollment?,
+        ruleEvent: RuleEvent?,
+        allEventValues: Map<String, List<RuleDataValueHistory>>,
+        currentEnrollmentValues: Map<String, RuleAttributeValue>,
+    ): Map<String, RuleVariableValue> =
+        buildEnvironmentVariables(allEvents, ruleEnrollment, ruleEvent) +
+            buildRuleVariableValues(ruleVariables, ruleEvent, allEventValues, currentEnrollmentValues) +
+            buildConstantsValues(allConstantValues)
 
     private fun buildCurrentEnrollmentValues(ruleEnrollment: RuleEnrollment): Map<String, RuleAttributeValue> =
         ruleEnrollment.attributeValues.associateBy {
@@ -255,17 +270,11 @@ internal class RuleVariableValueMapBuilder {
 
     private fun buildRuleVariableValues(
         ruleVariables: List<RuleVariable>,
-        ruleEvents: Set<RuleEvent>,
-        ruleEnrollment: RuleEnrollment?,
         ruleEvent: RuleEvent?,
-    ): Map<String, RuleVariableValue> {
-        // map data values within all events to data elements
-        val allEventValues = buildAllEventValues(ruleEvents)
-
-        // map tracked entity attributes to values from enrollment
-        val currentEnrollmentValues = ruleEnrollment?.let { buildCurrentEnrollmentValues(it) }.orEmpty()
-
-        return ruleVariables.associateBy(
+        allEventValues: Map<String, List<RuleDataValueHistory>>,
+        currentEnrollmentValues: Map<String, RuleAttributeValue>,
+    ): Map<String, RuleVariableValue> =
+        ruleVariables.associateBy(
             { it.name },
             {
                 it.createValues(
@@ -275,5 +284,4 @@ internal class RuleVariableValueMapBuilder {
                 )
             },
         )
-    }
 }

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
@@ -55,10 +55,13 @@ internal class RuleVariableValueMapBuilder {
         ruleEvent: RuleEvent?,
         allEventValues: Map<String, List<RuleDataValueHistory>>,
         currentEnrollmentValues: Map<String, RuleAttributeValue>,
-    ): Map<String, RuleVariableValue> =
-        buildEnvironmentVariables(allEvents, ruleEnrollment, ruleEvent) +
-            buildRuleVariableValues(ruleVariables, ruleEvent, allEventValues, currentEnrollmentValues) +
-            buildConstantsValues(allConstantValues)
+    ): Map<String, RuleVariableValue> {
+        val valueMap = HashMap<String, RuleVariableValue>()
+        fillEnvironmentVariables(allEvents, ruleEnrollment, ruleEvent, valueMap)
+        fillRuleVariableValues(ruleVariables, ruleEvent, allEventValues, currentEnrollmentValues, valueMap)
+        fillConstantsValues(allConstantValues, valueMap)
+        return valueMap
+    }
 
     private fun buildCurrentEnrollmentValues(ruleEnrollment: RuleEnrollment): Map<String, RuleAttributeValue> =
         ruleEnrollment.attributeValues.associateBy {
@@ -89,30 +92,32 @@ internal class RuleVariableValueMapBuilder {
         return allEventsValues.toMap()
     }
 
-    private fun buildConstantsValues(allConstantValues: Map<String, String>): Map<String, RuleVariableValue> =
-        allConstantValues.mapValues {
-            RuleVariableValue(RuleValueType.NUMERIC, it.value)
+    private fun fillConstantsValues(
+        allConstantValues: Map<String, String>,
+        valueMap: MutableMap<String, RuleVariableValue>,
+    ) {
+        allConstantValues.forEach { (key, value) ->
+            valueMap[key] = RuleVariableValue(RuleValueType.NUMERIC, value)
         }
+    }
 
-    private fun buildEnvironmentVariables(
+    private fun fillEnvironmentVariables(
         ruleEvents: Set<RuleEvent>,
         ruleEnrollment: RuleEnrollment?,
         ruleEvent: RuleEvent?,
-    ): Map<String, RuleVariableValue> {
+        valueMap: MutableMap<String, RuleVariableValue>,
+    ) {
         val currentDate = currentDate()
-
-        val environmentVariablesValuesMap = buildEnvironmentVariables(ruleEvents, currentDate)
-        val enrollmentVariableValueMap = ruleEnrollment?.let { buildEnrollmentEnvironmentVariables(it, currentDate) }.orEmpty()
-        val eventVariableValueMap = ruleEvent?.let { buildEventEnvironmentVariables(ruleEvents, it, currentDate) }.orEmpty()
-
-        return environmentVariablesValuesMap + enrollmentVariableValueMap + eventVariableValueMap
+        fillEnvironmentVariables(ruleEvents, currentDate, valueMap)
+        ruleEnrollment?.let { fillEnrollmentEnvironmentVariables(it, currentDate, valueMap) }
+        ruleEvent?.let { fillEventEnvironmentVariables(ruleEvents, it, currentDate, valueMap) }
     }
 
-    private fun buildEnvironmentVariables(
+    private fun fillEnvironmentVariables(
         ruleEvents: Set<RuleEvent>,
         currentDate: LocalDate,
-    ): Map<String, RuleVariableValue> {
-        val valueMap: MutableMap<String, RuleVariableValue> = HashMap()
+        valueMap: MutableMap<String, RuleVariableValue>,
+    ) {
         valueMap[RuleEngineUtils.ENV_VAR_CURRENT_DATE] =
             RuleVariableValue(
                 RuleValueType.DATE,
@@ -135,28 +140,25 @@ internal class RuleVariableValueMapBuilder {
                 listOf(environment),
                 currentDate.toString(),
             )
-
-        return valueMap.toMap()
     }
 
-    private fun buildEventEnvironmentVariables(
+    private fun fillEventEnvironmentVariables(
         ruleEvents: Set<RuleEvent>,
         ruleEvent: RuleEvent,
         currentDate: LocalDate,
-    ): Map<String, RuleVariableValue> {
-        val valueMap: MutableMap<String, RuleVariableValue> = HashMap()
-            val eventDate =
-                if (ruleEvent.eventDate < RuleLocalDate.distantFuture() )
+        valueMap: MutableMap<String, RuleVariableValue>,
+    ) {
+        val eventDate =
+            if (ruleEvent.eventDate < RuleLocalDate.distantFuture())
                 ruleEvent.eventDate.toString()
             else null
-            valueMap[RuleEngineUtils.ENV_VAR_EVENT_DATE] =
-                RuleVariableValue(
-                    RuleValueType.DATE,
-                    eventDate,
-                    eventDate?.let { listOf(it) } ?: emptyList(),
-                    currentDate.toString(),
-                )
-
+        valueMap[RuleEngineUtils.ENV_VAR_EVENT_DATE] =
+            RuleVariableValue(
+                RuleValueType.DATE,
+                eventDate,
+                eventDate?.let { listOf(it) } ?: emptyList(),
+                currentDate.toString(),
+            )
         valueMap[RuleEngineUtils.ENV_VAR_DUE_DATE] =
             RuleVariableValue(
                 RuleValueType.DATE,
@@ -194,24 +196,17 @@ internal class RuleVariableValueMapBuilder {
                 listOf(status),
                 currentDate.toString(),
             )
-        val organisationUnit = ruleEvent.organisationUnit
-        valueMap[RuleEngineUtils.ENV_VAR_OU] = RuleVariableValue(RuleValueType.TEXT, organisationUnit)
-        val programStageId = ruleEvent.programStage
-        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_STAGE_ID] = RuleVariableValue(RuleValueType.TEXT, programStageId)
-        val programStageName = ruleEvent.programStageName
-        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_STAGE_NAME] = RuleVariableValue(RuleValueType.TEXT, programStageName)
-        val organisationUnitCode = ruleEvent.organisationUnitCode
-        valueMap[RuleEngineUtils.ENV_VAR_OU_CODE] =
-            RuleVariableValue(RuleValueType.TEXT, organisationUnitCode)
-
-        return valueMap.toMap()
+        valueMap[RuleEngineUtils.ENV_VAR_OU] = RuleVariableValue(RuleValueType.TEXT, ruleEvent.organisationUnit)
+        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_STAGE_ID] = RuleVariableValue(RuleValueType.TEXT, ruleEvent.programStage)
+        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_STAGE_NAME] = RuleVariableValue(RuleValueType.TEXT, ruleEvent.programStageName)
+        valueMap[RuleEngineUtils.ENV_VAR_OU_CODE] = RuleVariableValue(RuleValueType.TEXT, ruleEvent.organisationUnitCode)
     }
 
-    private fun buildEnrollmentEnvironmentVariables(
+    private fun fillEnrollmentEnvironmentVariables(
         ruleEnrollment: RuleEnrollment,
         currentDate: LocalDate,
-    ): Map<String, RuleVariableValue> {
-        val valueMap: MutableMap<String, RuleVariableValue> = HashMap()
+        valueMap: MutableMap<String, RuleVariableValue>,
+    ) {
         valueMap[RuleEngineUtils.ENV_VAR_ENROLLMENT_ID] =
             RuleVariableValue(
                 RuleValueType.TEXT,
@@ -257,31 +252,20 @@ internal class RuleVariableValueMapBuilder {
                 listOf(status),
                 currentDate.toString(),
             )
-        val organisationUnit = ruleEnrollment.organisationUnit
-        valueMap[RuleEngineUtils.ENV_VAR_OU] = RuleVariableValue(RuleValueType.TEXT, organisationUnit)
-        val programName = ruleEnrollment.programName
-        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_NAME] = RuleVariableValue(RuleValueType.TEXT, programName)
-        val organisationUnitCode = ruleEnrollment.organisationUnitCode
-        valueMap[RuleEngineUtils.ENV_VAR_OU_CODE] =
-            RuleVariableValue(RuleValueType.TEXT, organisationUnitCode)
-
-        return valueMap.toMap()
+        valueMap[RuleEngineUtils.ENV_VAR_OU] = RuleVariableValue(RuleValueType.TEXT, ruleEnrollment.organisationUnit)
+        valueMap[RuleEngineUtils.ENV_VAR_PROGRAM_NAME] = RuleVariableValue(RuleValueType.TEXT, ruleEnrollment.programName)
+        valueMap[RuleEngineUtils.ENV_VAR_OU_CODE] = RuleVariableValue(RuleValueType.TEXT, ruleEnrollment.organisationUnitCode)
     }
 
-    private fun buildRuleVariableValues(
+    private fun fillRuleVariableValues(
         ruleVariables: List<RuleVariable>,
         ruleEvent: RuleEvent?,
         allEventValues: Map<String, List<RuleDataValueHistory>>,
         currentEnrollmentValues: Map<String, RuleAttributeValue>,
-    ): Map<String, RuleVariableValue> =
-        ruleVariables.associateBy(
-            { it.name },
-            {
-                it.createValues(
-                    ruleEvent,
-                    allEventValues,
-                    currentEnrollmentValues,
-                )
-            },
-        )
+        valueMap: MutableMap<String, RuleVariableValue>,
+    ) {
+        ruleVariables.forEach { variable ->
+            valueMap[variable.name] = variable.createValues(ruleEvent, allEventValues, currentEnrollmentValues)
+        }
+    }
 }

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/engine/RuleVariableValueMapBuilder.kt
@@ -19,7 +19,7 @@ internal class RuleVariableValueMapBuilder {
             ruleEvent?.let {
                 val set = HashSet(ruleEvents)
                 set.add(it)
-                set.toSet()
+                set
             } ?: ruleEvents
         val allEventValues = buildAllEventValues(allEvents)
         val currentEnrollmentValues = ruleEnrollment?.let { buildCurrentEnrollmentValues(it) }.orEmpty()

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/Rule.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/Rule.kt
@@ -15,6 +15,12 @@ data class Rule(
         if (condition.isEmpty()) Result.success(null)
         else runCatching { Expression(condition, ExpressionMode.RULE_ENGINE_CONDITION, false) }
 
+    internal val actionsForDataElement: List<RuleAction> =
+        actions.filter { it.attributeType() == null || it.attributeType() == AttributeType.DATA_ELEMENT.name || it.attributeType() == AttributeType.UNKNOWN.name }.sorted()
+
+    internal val actionsForEnrollment: List<RuleAction> =
+        actions.filter { it.attributeType() == null || it.attributeType() == AttributeType.TRACKED_ENTITY_ATTRIBUTE.name || it.attributeType() == AttributeType.UNKNOWN.name }.sorted()
+
     override fun compareTo(other: Rule): Int =
         if (this.priority != null && other.priority != null) {
             this.priority.compareTo(other.priority)

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/Rule.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/Rule.kt
@@ -1,5 +1,8 @@
 package org.hisp.dhis.rules.models
 
+import org.hisp.dhis.lib.expression.Expression
+import org.hisp.dhis.lib.expression.ExpressionMode
+
 data class Rule(
     val condition: String,
     val actions: List<RuleAction>,
@@ -8,6 +11,10 @@ data class Rule(
     val programStage: String? = null,
     val priority: Int? = null,
 ) : Comparable<Rule> {
+    internal val conditionExpression: Result<Expression?> =
+        if (condition.isEmpty()) Result.success(null)
+        else runCatching { Expression(condition, ExpressionMode.RULE_ENGINE_CONDITION, false) }
+
     override fun compareTo(other: Rule): Int =
         if (this.priority != null && other.priority != null) {
             this.priority.compareTo(other.priority)

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleAction.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleAction.kt
@@ -1,11 +1,18 @@
 package org.hisp.dhis.rules.models
 
+import org.hisp.dhis.lib.expression.Expression
+import org.hisp.dhis.lib.expression.ExpressionMode
+
 data class RuleAction(
     val data: String?,
     val type: String,
     val values: Map<String, String> = emptyMap(),
     val priority: Int? = null,
 ) : Comparable<RuleAction> {
+    internal val dataExpression: Result<Expression?> =
+        if (data.isNullOrEmpty()) Result.success(null)
+        else runCatching { Expression(data!!, ExpressionMode.RULE_ENGINE_ACTION, false) }
+
     fun content(): String? = values["content"]
 
     fun field(): String? = values["field"]

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleLocalDate.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleLocalDate.kt
@@ -33,11 +33,13 @@ data class RuleLocalDate(val year: Int, val month: Int, val day: Int): Comparabl
             return fromLocalDate(LocalDate.parse(dateString))
         }
 
+        private val DISTANT_FUTURE: RuleLocalDate by lazy {
+            fromLocalDate(Instant.DISTANT_FUTURE.toLocalDateTime(TimeZone.currentSystemDefault()).date)
+        }
+
         @JvmStatic
         @JsStatic
-        fun distantFuture(): RuleLocalDate {
-            return fromLocalDate(Instant.DISTANT_FUTURE.toLocalDateTime(TimeZone.currentSystemDefault()).date)
-        }
+        fun distantFuture(): RuleLocalDate = DISTANT_FUTURE
 
         internal fun fromLocalDate(localDate: LocalDate): RuleLocalDate {
             return RuleLocalDate(localDate.year, localDate.month.number, localDate.day)

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleValueType.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/models/RuleValueType.kt
@@ -1,6 +1,7 @@
 package org.hisp.dhis.rules.models
 
 import kotlin.js.JsExport
+import org.hisp.dhis.lib.expression.spi.ValueType
 
 @JsExport
 enum class RuleValueType(
@@ -13,4 +14,11 @@ enum class RuleValueType(
     ;
 
     fun defaultValue(): Any = defaultValue
+
+    internal fun toValueType(): ValueType = when (this) {
+        DATE -> ValueType.DATE
+        NUMERIC -> ValueType.NUMBER
+        BOOLEAN -> ValueType.BOOLEAN
+        else -> ValueType.STRING
+    }
 }

--- a/src/commonMain/kotlin/org/hisp/dhis/rules/utils/RuleEventUtils.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/rules/utils/RuleEventUtils.kt
@@ -6,6 +6,7 @@ import org.hisp.dhis.rules.models.RuleAction
 import org.hisp.dhis.rules.models.RuleDataValueHistory
 import org.hisp.dhis.rules.models.RuleEvent
 
+
 /*
 * Copyright (c) 2004-2026, University of Oslo
 * All rights reserved.
@@ -49,49 +50,16 @@ internal fun getPreviousDataValue(dataValues: List<RuleDataValueHistory>, ruleEv
     return null
 }
 
-internal fun filterRules(rules: List<Rule>): List<Rule> {
-    val filteredRules: MutableList<Rule> = mutableListOf()
-    for (rule in rules) {
-        val programStage: String? = rule.programStage
-        if (programStage.isNullOrEmpty()) {
-            val ruleActions =
-                filterActionRules(
-                    rule.actions,
-                    AttributeType.TRACKED_ENTITY_ATTRIBUTE,
-                )
-            filteredRules.add(rule.copy(actions = ruleActions))
-        }
-    }
-    return filteredRules
-}
+internal fun filterRules(rules: List<Rule>): List<Rule> =
+    rules.filter { it.programStage.isNullOrEmpty() }
 
 internal fun filterRules(
     rules: List<Rule>,
     ruleEvent: RuleEvent,
-): List<Rule> {
-    val filteredRules: MutableList<Rule> = mutableListOf()
-    for (rule in rules) {
-        val programStage: String? = rule.programStage
-        if (programStage.isNullOrEmpty() || programStage == ruleEvent.programStage) {
-            val ruleActions =
-                filterActionRules(
-                    rule.actions,
-                    AttributeType.DATA_ELEMENT,
-                )
-            filteredRules.add(rule.copy(actions = ruleActions))
-        }
-    }
-    return filteredRules
-}
+): List<Rule> =
+    rules.filter { it.programStage.isNullOrEmpty() || it.programStage == ruleEvent.programStage }
 
-private fun filterActionRules(
-    ruleActions: List<RuleAction>,
-    attributeType: AttributeType,
-): List<RuleAction> {
-    return ruleActions.filter {
-        it.attributeType() == null ||
-            it.attributeType() == attributeType.name ||
-            it.attributeType() == AttributeType.UNKNOWN.name
-    }
-
-}
+internal fun isAllowedAction(ruleAction: RuleAction, attributeType: AttributeType): Boolean =
+    ruleAction.attributeType() == null ||
+        ruleAction.attributeType() == attributeType.name ||
+        ruleAction.attributeType() == AttributeType.UNKNOWN.name

--- a/src/commonTest/kotlin/org/hisp/dhis/rules/RuleVariableValueAssert.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/rules/RuleVariableValueAssert.kt
@@ -1,11 +1,11 @@
 package org.hisp.dhis.rules
 
-import org.hisp.dhis.rules.engine.RuleVariableValue
+import org.hisp.dhis.lib.expression.spi.VariableValue
 import org.hisp.dhis.rules.models.RuleValueType
 import kotlin.test.assertEquals
 
 internal class RuleVariableValueAssert private constructor(
-    private val variableValue: RuleVariableValue,
+    private val variableValue: VariableValue,
 ) {
     fun hasValue(value: String?): RuleVariableValueAssert {
         assertEquals(value, variableValue.value)
@@ -21,11 +21,11 @@ internal class RuleVariableValueAssert private constructor(
     }
 
     fun isTypeOf(valueType: RuleValueType?): RuleVariableValueAssert {
-        assertEquals(valueType, variableValue.type)
+        assertEquals(valueType?.toValueType(), variableValue.valueType)
         return this
     }
 
     companion object {
-        fun assertThatVariable(variableValue: RuleVariableValue): RuleVariableValueAssert = RuleVariableValueAssert(variableValue)
+        fun assertThatVariable(variableValue: VariableValue): RuleVariableValueAssert = RuleVariableValueAssert(variableValue)
     }
 }

--- a/src/commonTest/kotlin/org/hisp/dhis/rules/models/RuleTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/rules/models/RuleTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 class RuleTest {
     @Test
     fun createShouldPropagatePropertiesCorrectly() {
-        val ruleAction = RuleAction("data", "ERROR")
+        val ruleAction = RuleAction("'data'", "ERROR")
         val (condition, actions, uid, _, programStage, priority) =
             Rule(
                 "test_condition",


### PR DESCRIPTION
Profiling with JFR (Java Flight Recorder) showed the rule engine was allocating **5.76 GB** per evaluation run (baseline, run 23531158240). This PR reduces that to **~0.83 GB** — an **~86% reduction** — by eliminating redundant allocations across the hot evaluation path.

All changes were identified from collapsed-stack allocation profiles targeting the heaviest hotspots in `DefaultProgramRuleService`.

## Changes

| Change| Baseline hotspot | Est. savings |                                                                                                                                         
  |-----------|--------------------------|------------------|
| Hoist `buildAllEventValues` out of the per-event loop — it was recomputing `RuleDataValueHistory` objects N×M times, once per evaluated event                                                                                                                                                                                                                                                                                                                                                                                                                           | `RuleDataValueHistory` repeated construction: **~1336 MB** + sort/list overhead: **~340 MB**                                                                                                                        | **~1676 MB** |
| Eliminate `+` map-merge allocations in `build()` — replaced additive map merges with a single pre-allocated mutable map threaded through all fill methods                                                                                                                                                                                                                                                                                                                                                                                                               | Map merge intermediates per event: **~44 MB**                                                                                                                                                                       | **~44 MB**   |
| Replace O(2N) `sorted()` copy chain with a direct descending sort in `buildAllEventValues`                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | `orderEvents()` per-event list copies: **~85 MB**                                                                                                                                                                   | **~85 MB**   |                 
| Drop `.toSet()` copy in `build()` — the event set was already a `Set<RuleEvent>`, the defensive copy was unnecessary                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Minor set allocation overhead                                                                                                                                                                                       | **~5 MB**    |              
| Use `VariableValue` directly throughout — eliminated two large intermediate allocations: (1) `process()` called `mapValues { it.toVariableValue() }` creating a full `LinkedHashMap` copy per expression evaluation, and (2) `getRuleEvaluationResults` called `toMutableMap()` for another full copy; both paths now thread `MutableMap<String, VariableValue>` from construction                                                                                                                                                                                      | `process()` LinkedHashMap copy: **~1285 MB** + `getRuleEvaluationResults` `toMutableMap()` copy: **~491 MB** + `RuleVariableValue` intermediate wrappers: **~93 MB**                                                | **~1869 MB** |                                                                                                                                                                                
| Pre-compile `Expression` objects at `Rule`/`RuleAction` construction time — the expression parser (regex/Pattern allocation) was re-run on every evaluation call                                                                                                                                                                                                                                                                                                                                                                                                        | Expression parsing per evaluation: **~239 MB**                                                                                                                                                                      | **~239 MB**  |                                                                                                                                           
| Move `convertSupplementaryData` conversion up to once per `evaluateAll` call — it was rebuilding the supplementary `HashMap` on every single `process()` invocation                                                                                                                                                                                                                                                                                                                                                                                                     | `convertSupplementaryData` per expression: **~18 MB**                                                                                                                                                               | **~18 MB**   |                                                                                                                          
| Several smaller fixes from a follow-up profile (run 23598404065): pre-sort and pre-group rules by stage (eliminates `filterRules`/`sorted()` inside evaluation loops), compute `currentDate()` once per `multipleBuild` instead of per event, cache `currentDate.toString()` as a local val (was called 2–3× per `VariableValue` construction), cache `distantFuture()` as a lazy companion val (was computing `Instant.DISTANT_FUTURE.toLocalDateTime(TimeZone.currentSystemDefault())` per event), reuse a single `RuleConditionEvaluator` instance across all events | `filterRules`/`filterActionRules`: **~11 MB** + `currentDate.toString()` repeated: **~28 MB** + `currentDate()` per event: **~14 MB** + `distantFuture()` per event: **~10 MB** + evaluator construction: **~5 MB** | **~68 MB**   |

## Measured Results

[Performance test](https://github.com/dhis2/dhis2-core/actions/runs/23604708134) comparing master vs this PR using Load profile, 4 users, 30k entities/program, importing 2 programs with 3 rules (2 runs on server, 1 is ignored) each and 1 program with no rules.

| | Master | This PR | Delta | Delta % |
|---|---:|---:|---:|---:|
| **Total** | 31.41 GB | 26.45 GB | -4.97 GB | -15.8% |
| **rule-engine** | 5.76 GB | 0.83 GB | -4.92 GB | -85.5% |
| **% PRS** | 18.3% | 3.1% | | |

**Total reduction: ~86%**

## Testing

Existing test suite passes. No behaviour changes — all modifications are strictly in
allocation/caching of computed values that were previously recomputed identically on every call.