### PR TITLE
chore: [skip publish] Add kover and sonarqube to Rule Engine 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
@@ -29,6 +31,14 @@ jobs:
 
       - name: API Check
         run: ./gradlew apiCheck
+
+      - name: Generate Kover reports
+        run: ./gradlew koverXmlReport
+
+      - name: Run SonarCloud Analysis
+        run: ./gradlew sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   publish:
     needs: unit-test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
@@ -23,6 +25,14 @@ jobs:
 
       - name: API Check
         run: ./gradlew apiCheck
+
+      - name: Generate Kover reports
+        run: ./gradlew koverXmlReport
+
+      - name: Run SonarCloud Analysis
+        run: ./gradlew sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   publish:
     name: Publish

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.hisp.dhis.rules/rule-engine?label=maven%20central)](https://central.sonatype.com/artifact/org.hisp.dhis.rules/rule-engine)
 [![NPM Version](https://img.shields.io/npm/v/@dhis2/rule-engine)](https://www.npmjs.com/package/@dhis2/rule-engine)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dhis2_dhis2-rule-engine&metric=coverage&branch=master)](https://sonarcloud.io/summary/new_code?id=dhis2_dhis2-rule-engine&branch=master)
 [![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://dhis2.github.io/dhis2-rule-engine/api/)
 
 ### RuleEngine (WIP)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("maven-publish-conventions")
     id("npm-publish-conventions")
     alias(libs.plugins.api.compatibility)
+    alias(libs.plugins.kover)
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("npm-publish-conventions")
     alias(libs.plugins.api.compatibility)
     alias(libs.plugins.kover)
+    alias(libs.plugins.sonarqube)
 }
 
 repositories {
@@ -89,4 +90,18 @@ kotlin {
         val nativeMain by getting
         val nativeTest by getting
     }
+}
+
+sonarqube {
+    properties {
+        property("sonar.host.url", "https://sonarcloud.io")
+        property("sonar.organization", "dhis2")
+        property("sonar.projectKey", "dhis2_dhis2-rule-engine")
+        property("sonar.projectName", "dhis2-rule-engine")
+        property("sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory.get()}/reports/kover/report.xml")
+    }
+}
+
+tasks.named("sonar").configure {
+    dependsOn(":koverXmlReport")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ nexusPublish = "2.0.0"
 npmPublish = "3.5.2"
 apiCompatibility ="0.17.0"
 kover = "0.9.8"
+sonarqube = "7.2.3.7755"
+
 kotlinxDatetime = "0.7.1"
 kotlinJsWrappers = "1.0.0-pre.830"
 slf4jApi = "1.7.36"
@@ -25,5 +27,6 @@ dhis-expression-parser = { group = "org.hisp.dhis.lib.expression", name = "expre
 [plugins]
 api-compatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "apiCompatibility" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 
 [bundles]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ dokka = "2.0.0"
 nexusPublish = "2.0.0"
 npmPublish = "3.5.2"
 apiCompatibility ="0.17.0"
+kover = "0.9.8"
 kotlinxDatetime = "0.7.1"
 kotlinJsWrappers = "1.0.0-pre.830"
 slf4jApi = "1.7.36"
@@ -23,5 +24,6 @@ dhis-expression-parser = { group = "org.hisp.dhis.lib.expression", name = "expre
 
 [plugins]
 api-compatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "apiCompatibility" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 
 [bundles]


### PR DESCRIPTION
Add the Kover plugin to generate code coverage reports.
Enable the Sonarqube plugin to publish code coverage reports to SonarCloud.

Add a code coverage badge in README.md.