### PR TITLE
chore: [skip publish] Add branch information to Sonar analysis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
         run: ./gradlew sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GIT_BRANCH: ${{ github.ref_name }}
 
   publish:
     needs: unit-test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,6 +33,9 @@ jobs:
         run: ./gradlew sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GIT_BRANCH: ${{ github.ref_name}}
+          GIT_BRANCH_DEST: ${{ github.base_ref }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
 
   publish:
     name: Publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,11 +94,23 @@ kotlin {
 
 sonarqube {
     properties {
+        val branch = System.getenv("GIT_BRANCH")
+        val targetBranch = System.getenv("GIT_BRANCH_DEST")
+        val pullRequestId = System.getenv("PULL_REQUEST")
+
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.organization", "dhis2")
         property("sonar.projectKey", "dhis2_dhis2-rule-engine")
         property("sonar.projectName", "dhis2-rule-engine")
         property("sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory.get()}/reports/kover/report.xml")
+
+        if (pullRequestId.isNullOrEmpty()) {
+            property("sonar.branch.name", branch)
+        } else {
+            property("sonar.pullrequest.base", targetBranch)
+            property("sonar.pullrequest.branch", branch)
+            property("sonar.pullrequest.key", pullRequestId)
+        }
     }
 }
 


### PR DESCRIPTION
Add missing branch information for Sonar report. I thought it was automatically fetched by the Sonar plugin, but it doesn't seem to work and needs to be explicitly provided.